### PR TITLE
I added a cross-platform implementation of pyodbc.drivers()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,8 +155,20 @@ def get_compiler_settings(version_str):
 
         settings['define_macros'].append( ('MAC_OS_X_VERSION_10_7',) )
 
+    elif sys.platform.startswith('linux'):
+        # Python functions take a lot of 'char *' that really should be const.  gcc complains about this *a lot*
+        settings['extra_compile_args'] = ['-Wno-write-strings']
+
+        # Find a shared library in the usual places by the name of lib[i]odbc.so*
+        from subprocess import Popen, PIPE
+        print 'Detecting the available ODBC driver manager...'
+        p = Popen(['find', '/usr/lib', '/usr/local/lib', '-type', 'f', '-regex', r'.*/libi?odbc\.so.*'], stdout=PIPE, stderr=PIPE)
+        out = p.communicate()[0]
+        if not out:
+            print '''Warning: ODBC driver manager missing. Please install the development versions of either unixODBC or iODBC'''
+        settings['libraries'].append('iodbc' if re.search(r'.*/libiodbc\.so.*', out) else 'odbc')
     else:
-        # Other posix-like: Linux, Solaris, etc.
+        # Other posix-like: Solaris, etc.
 
         # Python functions take a lot of 'char *' that really should be const.  gcc complains about this *a lot*
         settings['extra_compile_args'] = ['-Wno-write-strings']

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -372,6 +372,49 @@ static PyObject* mod_connect(PyObject* self, PyObject* args, PyObject* kwargs)
 }
 
 
+static PyObject* mod_drivers(PyObject* self)
+{
+    UNUSED(self);
+
+    if (henv == SQL_NULL_HANDLE && !AllocateEnv())
+        return 0;
+
+    PyObject* result = PyList_New(0);
+    if (!result)
+        return 0;
+
+    SQLCHAR szDriverDesc[SQL_MAX_DSN_LENGTH];
+    SWORD cbDriverDesc;
+    SQLCHAR szDesc[200];
+    SWORD cbDesc;
+
+    SQLUSMALLINT nDirection = SQL_FETCH_FIRST;
+
+    SQLRETURN ret;
+
+    for (;;)
+    {
+        Py_BEGIN_ALLOW_THREADS
+        ret = SQLDrivers(henv, nDirection, szDriverDesc,  _countof(szDriverDesc),  &cbDriverDesc, szDesc, _countof(szDesc), &cbDesc);
+        Py_END_ALLOW_THREADS
+        if (!SQL_SUCCEEDED(ret))
+            break;
+
+        if (PyList_Append(result, PyString_FromString((const char*)szDriverDesc)) != 0)
+            return 0;
+        nDirection = SQL_FETCH_NEXT;
+    }
+
+    if (ret != SQL_NO_DATA)
+    {
+        Py_DECREF(result);
+        return RaiseErrorFromHandle("SQLDrivers", SQL_NULL_HANDLE, SQL_NULL_HANDLE);
+    }
+
+    return result;
+}
+
+
 static PyObject* mod_datasources(PyObject* self)
 {
     UNUSED(self);
@@ -526,8 +569,13 @@ static char timestampfromticks_doc[] =
     "seconds since the epoch; see the documentation of the standard Python time\n" \
     "module for details";
 
+static char drivers_doc[] =
+    "drivers() --> [ DriverName1, DriverName2 ... DriverNameN ]\n" \
+    "\n" \
+    "Returns a list of installed drivers.";
+
 static char datasources_doc[] =
-    "dataSources() -> { DSN : Description }\n" \
+    "dataSources() --> { DSN : Description }\n" \
     "\n" \
     "Returns a dictionary mapping available DSNs to their descriptions.";
 
@@ -541,43 +589,6 @@ static PyObject* mod_leakcheck(PyObject* self, PyObject* args)
 }
 #endif
 
-#ifdef WINVER
-static char drivers_doc[] = "drivers() -> [ driver, ... ]\n\nReturns a list of installed drivers";
-
-static PyObject* mod_drivers(PyObject* self, PyObject* args)
-{
-    UNUSED(self, args);
-
-    RegKey key;
-    long ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\ODBC\\ODBCINST.INI\\ODBC Drivers", 0, KEY_QUERY_VALUE, &key.hkey);
-    if (ret != ERROR_SUCCESS)
-        return PyErr_Format(PyExc_RuntimeError, "Unable to access the driver list in the registry.  error=%ld", ret);
-
-    Object results(PyList_New(0));
-    DWORD index = 0;
-    char name[255];
-    DWORD length = _countof(name);
-
-    while (RegEnumValue(key, index++, name, &length, 0, 0, 0, 0) == ERROR_SUCCESS)
-    {
-        if (ret != ERROR_SUCCESS)
-            return PyErr_Format(PyExc_RuntimeError, "RegEnumKeyEx failed with error %ld\n", ret);
-
-        PyObject* oname = PyString_FromStringAndSize(name, (Py_ssize_t)length);
-        if (!oname)
-            return 0;
-
-        if (PyList_Append(results.Get(), oname) != 0)
-        {
-            Py_DECREF(oname);
-            return 0;
-        }
-        length = _countof(name);
-    }
-
-    return results.Detach();
-}
-#endif
 
 static PyMethodDef pyodbc_methods[] =
 {
@@ -585,11 +596,8 @@ static PyMethodDef pyodbc_methods[] =
     { "TimeFromTicks",      (PyCFunction)mod_timefromticks,      METH_VARARGS,               timefromticks_doc },
     { "DateFromTicks",      (PyCFunction)mod_datefromticks,      METH_VARARGS,               datefromticks_doc },
     { "TimestampFromTicks", (PyCFunction)mod_timestampfromticks, METH_VARARGS,               timestampfromticks_doc },
+    { "drivers",            (PyCFunction)mod_drivers,            METH_NOARGS,                drivers_doc },
     { "dataSources",        (PyCFunction)mod_datasources,        METH_NOARGS,                datasources_doc },
-
-#ifdef WINVER
-    { "drivers", (PyCFunction)mod_drivers, METH_NOARGS, drivers_doc },
-#endif
 
 #ifdef PYODBC_LEAK_CHECK
     { "leakcheck", (PyCFunction)mod_leakcheck, METH_NOARGS, 0 },

--- a/tests2/accesstests.py
+++ b/tests2/accesstests.py
@@ -111,6 +111,10 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests2/freetdstests.py
+++ b/tests2/freetdstests.py
@@ -121,6 +121,10 @@ class FreeTDSTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -108,6 +108,10 @@ class InformixTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -98,6 +98,10 @@ class MySqlTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests2/pgtests.py
+++ b/tests2/pgtests.py
@@ -69,6 +69,10 @@ class PGTestCase(unittest.TestCase):
             # If we've already closed the cursor or connection, exceptions are thrown.
             pass
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests2/sqlitetests.py
+++ b/tests2/sqlitetests.py
@@ -107,6 +107,10 @@ class SqliteTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -135,6 +135,10 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests3/accesstests.py
+++ b/tests3/accesstests.py
@@ -111,6 +111,10 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -108,6 +108,10 @@ class InformixTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -98,6 +98,10 @@ class MySqlTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -68,6 +68,10 @@ class PGTestCase(unittest.TestCase):
             # If we've already closed the cursor or connection, exceptions are thrown.
             pass
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -107,6 +107,10 @@ class SqliteTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -123,6 +123,10 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", 1)
         self.cursor.execute("insert into t2 values (?)", datetime.now())
 
+    def test_drivers(self):
+        p = pyodbc.drivers()
+        self.assert_(isinstance(p, list))
+
     def test_datasources(self):
         p = pyodbc.dataSources()
         self.assert_(isinstance(p, dict))


### PR DESCRIPTION
Hi Michael:

I removed the windows only version of pyodbc.drivers() and added an OS independent version of it, along with its tests. I tested that with iODBC in Ubuntu 12.04 x86.
