### PR TITLE
Add SQL_WCHART_CONVERT for UnixODBC. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,9 @@ def get_compiler_settings(version_str):
         # Python functions take a lot of 'char *' that really should be const.  gcc complains about this *a lot*
         settings['extra_compile_args'] = ['-Wno-write-strings']
 
+        # This makes UnixODBC use UCS-4 instead of UCS-2, which works better with sizeof(wchar_t)==4
+        settings['extra_compile_args'].append('-DSQL_WCHART_CONVERT=1')
+
         # What is the proper way to detect iODBC, MyODBC, unixODBC, etc.?
         settings['libraries'].append('odbc')
 

--- a/src/test_unicode_size.c
+++ b/src/test_unicode_size.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <sql.h>
+#include <sqlext.h>
+#include <Python.h>
+
+int main() {
+#ifdef HAVE_WCHAR_H
+  if (sizeof(SQLWCHAR) != sizeof(wchar_t)) {
+    printf("-DSQL_WCHART_CONVERT=1");
+  }
+#else
+  if (sizeof(SQLWCHAR) != sizeof(Py_UNICODE)) {
+    printf("-DSQL_WCHART_CONVERT=1");
+  }
+#endif
+}

--- a/tests3/testunicode.py
+++ b/tests3/testunicode.py
@@ -1,0 +1,10 @@
+import pyodbc
+cnxn = pyodbc.connect("DSN=VOS")
+cursor = cnxn.cursor()
+ustr=u"a\u8c22\u00e9"
+cursor.execute("CREATE TABLE unicode_test (name NVARCHAR)")
+cursor.execute("INSERT into unicode_test values (?)", ustr)
+cursor.execute("SELECT name from unicode_test")
+result = cursor.fetchone()[0]
+cursor.execute("DROP TABLE unicode_test")
+assert result == ustr


### PR DESCRIPTION
The simple test in testunicode.py fails otherwise, on Ubuntu 64 i686, with a 64 bit driver. (Virtuoso)
This is not yet final code, I will package it better once I hear confirmation that it does not break other configurations, or create tests otherwise.
I'm sending it as a pull request in this state to raise the issue.
