### PR TITLE
Invalid parameter values passed in, due to size mismatch.

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -302,7 +302,7 @@ static bool GetIntInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo
     info.Data.l = PyInt_AsLong(param);
 
 #if LONG_BIT == 64
-    info.ValueType     = SQL_C_SBIGINT;
+    info.ValueType     = SQL_C_LONG;
     info.ParameterType = SQL_BIGINT;
 #elif LONG_BIT == 32
     info.ValueType     = SQL_C_LONG;


### PR DESCRIPTION
Thank you very much for the last correction.
This one is quite important:
we get very wrong parameter values. I still have to write a test case for it, but I thought you should run your own testcases against it as-is.
