### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,13 +160,14 @@ def get_compiler_settings(version_str):
 
     elif sys.platform == 'darwin':
         # OS/X now ships with iODBC.
-        settings['libraries'].append('iodbc')
+        settings['libraries'].append('odbc')
 
         # Python functions take a lot of 'char *' that really should be const.  gcc complains about this *a lot*
         settings['extra_compile_args'].extend([
             '-Wno-write-strings',
             '-Wno-deprecated-declarations'
         ])
+        setting['extra_link_args'] = ['-L/usr/local/lib']
 
         # Apple has decided they won't maintain the iODBC system in OS/X and has added deprecation warnings in 10.8.
         # For now target 10.7 to eliminate the warnings.


### PR DESCRIPTION
Fixes problems related with "ld: library not found for -lodbc" during the build phase. Considering you're compiling on OS X 10.9 or 10.10 and installed unixodbc with homebrew