### PR TITLE
Trapping errors on nextset (plus couple of bugfixes which prevented compilation)

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -540,7 +540,6 @@ bool InitColumnInfo(Cursor* cursor, SQLUSMALLINT iCol, ColumnInfo* pinfo)
         RaiseErrorV(0, ProgrammingError, "The cursor's connection was closed.");
         return false;
     }
-
     if (!SQL_SUCCEEDED(ret))
     {
         RaiseErrorFromHandle("SQLDescribeCol", cursor->cnxn->hdbc, cursor->hstmt);
@@ -1707,6 +1706,37 @@ static PyObject* Cursor_nextset(PyObject* self, PyObject* args)
     if (ret == SQL_NO_DATA)
     {
         free_results(cur, FREE_STATEMENT | KEEP_PREPARED);
+        Py_RETURN_FALSE;
+    }
+    if (!SQL_SUCCEEDED(ret))
+    {
+        TRACE("nextset: %d not SQL_SUCCEEDED\n", ret);
+        // Note: The SQL Server driver sometimes returns HY007 here if multiple statements (separated by ;) were
+        // submitted.  This is not documented, but I've seen it with multiple successful inserts.
+
+        PyObject* pError = GetErrorFromHandle("SQLMoreResults", cur->cnxn->hdbc, cur->hstmt);
+        //
+        // free_results must be run after the error has been collected
+        // from the cursor as it's lost otherwise. 
+        // If free_results raises an error (eg a lost connection) report that instead.
+        //
+        if (!free_results(cur, FREE_STATEMENT | KEEP_PREPARED)) {
+            return 0;
+        }
+        //
+        // Return any error from the GetErrorFromHandle call above.
+        //
+        if (pError)
+        {
+            RaiseErrorFromException(pError);
+            Py_DECREF(pError);
+            return 0;
+        }
+        
+        //
+        // Not clear how we'd get here, but if we're in an error state
+        // without an error, behave as if we had no nextset
+        //
         Py_RETURN_FALSE;
     }
 

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -462,7 +462,7 @@ static PyObject* GetDataDecimal(Cursor* cur, Py_ssize_t iCol)
 
     // TODO: Is Unicode a good idea for Python 2.7?  We need to know which drivers support Unicode.
 
-    int buffsize = 100;
+    const int buffsize = 100;
     SQLWCHAR buffer[buffsize];
     SQLLEN cbFetched = 0; // Note: will not include the NULL terminator.
 

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -183,6 +183,7 @@ static bool import_types()
     PyObject* decimalmod = PyImport_ImportModule("cdecimal");
     if (!decimalmod)
     {
+        PyErr_Clear();
         decimalmod = PyImport_ImportModule("decimal");
         if (!decimalmod) {
             PyErr_SetString(PyExc_RuntimeError, "Unable to import cdecimal or decimal");

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -182,6 +182,12 @@ class SqlServerTestCase(unittest.TestCase):
         for i, row in enumerate(self.cursor):
             self.assertEqual(i + 2, row.i)
 
+    def test_nextset_with_raiserror(self):
+        self.cursor.execute("select i = 1; RAISERROR('c', 16, 1);")
+        row = next(self.cursor)
+        self.assertEqual(1, row.i)
+        self.assertRaises(pyodbc.ProgrammingError, self.cursor.nextset)
+    
     def test_fixed_unicode(self):
         value = u"t\xebsting"
         self.cursor.execute("create table t1(s nchar(7))")

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -170,6 +170,12 @@ class SqlServerTestCase(unittest.TestCase):
         for i, row in enumerate(self.cursor):
             self.assertEqual(i + 2, row.i)
 
+    def test_nextset_with_raiserror(self):
+        self.cursor.execute("select i = 1; RAISERROR('c', 16, 1);")
+        row = next(self.cursor)
+        self.assertEqual(1, row.i)
+        self.assertRaises(pyodbc.ProgrammingError, self.cursor.nextset)
+    
     def test_fixed_unicode(self):
         value = "t\xebsting"
         self.cursor.execute("create table t1(s nchar(7))")


### PR DESCRIPTION
As things stood, a nextset would error out with an unhelpful ("HY000") error if it encountered a SQL exception or an explicit RAISERROR. This patch builds the exception before freeing the cursor.

While building, there was one compilcation error on and one runtime error which I've also patched. (I'm running on Windows 7, Python 2.7-32 against SQL 2008 but I've tested on Python 3.4-64 as well).