### PR TITLE
Fix cursor.description for SQL_*BINARY columns

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -199,8 +199,8 @@ static PyObject* PythonTypeFromSqlType(Cursor* cur, const SQLCHAR* name, SQLSMAL
     case SQL_BINARY:
     case SQL_VARBINARY:
     case SQL_LONGVARBINARY:
-#if PY_MAJOR_VERSION >= 3
-        pytype = (PyObject*)&PyBytes_Type;
+#if PY_VERSION_HEX >= 0x02060000
+        pytype = (PyObject*)&PyByteArray_Type;
 #else
         pytype = (PyObject*)&PyBuffer_Type;
 #endif


### PR DESCRIPTION
Looking at src/getdata.cpp, it looks like we return a bytearray on python >= 2.6, so shouldn't claim to return a 'buffer' object (2.6 and 2.7) or 'bytes' (3.x).