### PR TITLE
Applied patch for UTF-16 encoding on 64 bit machines

### DIFF
--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -316,7 +316,8 @@ static PyObject* GetDataString(Cursor* cur, Py_ssize_t iCol)
     case SQL_WCHAR:
     case SQL_WVARCHAR:
     case SQL_WLONGVARCHAR:
-        nTargetType  = SQL_C_WCHAR;
+        //nTargetType  = SQL_C_WCHAR;
+	nTargetType = SQL_C_CHAR;
         break;
 
     default:


### PR DESCRIPTION
Had a problem encoding utf16 strings from Netezza on Centos 6.4 64bit. 

Found the fix/issue here:

https://code.google.com/p/pyodbc/issues/attachmentText?id=78&aid=5030789027258594097&name=wchar-fix.diff&token=ABZ6GAdn5zYg0bHJULckOP3EJLUwwp2ZtA%3A1440428010841
