### PR TITLE
adding homedir brew as a possible path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ def get_compiler_settings(version_str):
         settings['define_macros'].append( ('MAC_OS_X_VERSION_10_7',) )
 
         # Add directories for MacPorts and Homebrew.
-        dirs = ['/usr/local/include', '/opt/local/include']
+        dirs = ['/usr/local/include', '/opt/local/include','~/homebrew/include']
         settings['include_dirs'].extend(dir for dir in dirs if isdir(dir))
 
     else:


### PR DESCRIPTION
for certain OSX environments, its not possible to use /usr/local as the prefix for brew, and the standard recommended prefix for alternative installs is $HOMEDIR/homebrew

cc @ilovezfs and @cartazio for external feedback on this homebrew lore.

This would help fix up a lot of issues for folks on my team, and possibly other enterprisey python3 users on OSX. 

many thanks! 
