### PR TITLE
Forbid copy constructor use which may ends in an extra decref on objects

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -21,7 +21,7 @@
 static char connection_doc[] =
     "Connection objects manage connections to the database.\n"
     "\n"
-    "Each manages a single ODBC HDBC.";
+    "Each connection manages a single ODBC HDBC.";
 
 static Connection* Connection_Validate(PyObject* self)
 {

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -422,7 +422,8 @@ static bool GetDecimalInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Param
     // string.  Unfortunately, the Decimal class doesn't seem to have a way to force it to return a string without
     // exponents, so we'll have to build it ourselves.
 
-    Object t = PyObject_CallMethod(param, "as_tuple", 0);
+    Object t;
+    t = PyObject_CallMethod(param, "as_tuple", 0);
     if (!t)
         return false;
 

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -137,14 +137,14 @@ Py_UNICODE chDecimal = '.';
 //
 static void init_locale_info()
 {
-    Object module = PyImport_ImportModule("locale");
+    Object module(PyImport_ImportModule("locale"));
     if (!module)
     {
         PyErr_Clear();
         return;
     }
 
-    Object ldict = PyObject_CallMethod(module, "localeconv", 0);
+    Object ldict(PyObject_CallMethod(module, "localeconv", 0));
     if (!ldict)
     {
         PyErr_Clear();
@@ -281,7 +281,7 @@ static PyObject* mod_connect(PyObject* self, PyObject* args, PyObject* kwargs)
 {
     UNUSED(self);
 
-    Object pConnectString = 0;
+    Object pConnectString;
     int fAutoCommit = 0;
     int fAnsi = 0;              // force ansi
     int fUnicodeResults = 0;

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -7,12 +7,13 @@ class Object
 protected:
     PyObject* p;
 
-    // GCC freaks out if these are private, but it doesn't use them (?)
-    // Object(const Object& illegal);
-    // void operator=(const Object& illegal);
+private:
+    Object(const Object& illegal);
+    void operator=(const Object& illegal);
 
 public:
-    Object(PyObject* _p = 0)
+    Object() : p(NULL) {};
+    Object(PyObject* _p)
     {
         p = _p;
     }


### PR DESCRIPTION
The tests against postgresql with python 3 are ok
