### PR TITLE
exposed sql native type via cursor->description

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -321,14 +321,16 @@ static bool create_name_map(Cursor* cur, SQLSMALLINT field_count, bool lower)
             }
         }
 
-        colinfo = Py_BuildValue("(sOOiiiO)",
+        colinfo = Py_BuildValue("(sOOiiiOi)",
                                 (char*)name,
                                 type,                // type_code
                                 Py_None,             // display size
                                 (int)nColSize,       // internal_size
                                 (int)nColSize,       // precision
                                 (int)cDecimalDigits, // scale
-                                nullable_obj);       // null_ok
+                                nullable_obj,        // null_ok
+                                (int)nDataType
+                                );
         if (!colinfo)
             goto done;
 


### PR DESCRIPTION
I was missing a way how to get information about SQL datatype returned by the cursor. This way, the exposed SQL type code enables user to get type's info via cursor's getTypeInfo() method. 