### PR TITLE
Retrieve Unicode diagnostic messages

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -81,7 +81,7 @@ static bool Connect(PyObject* pConnectString, HDBC hdbc, bool fAnsi, long timeou
         ret = SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)(uintptr_t)timeout, SQL_IS_UINTEGER);
         Py_END_ALLOW_THREADS
         if (!SQL_SUCCEEDED(ret))
-            RaiseErrorFromHandle("SQLSetConnectAttr(SQL_ATTR_LOGIN_TIMEOUT)", hdbc, SQL_NULL_HANDLE);
+            RaiseErrorFromHandle(0, "SQLSetConnectAttr(SQL_ATTR_LOGIN_TIMEOUT)", hdbc, SQL_NULL_HANDLE);
     }
 
     if (!fAnsi)
@@ -108,7 +108,7 @@ static bool Connect(PyObject* pConnectString, HDBC hdbc, bool fAnsi, long timeou
     if (SQL_SUCCEEDED(ret))
         return true;
 
-    RaiseErrorFromHandle("SQLDriverConnect", hdbc, SQL_NULL_HANDLE);
+    RaiseErrorFromHandle(0, "SQLDriverConnect", hdbc, SQL_NULL_HANDLE);
 
     return false;
 }
@@ -133,7 +133,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, bool fAnsi,
     ret = SQLAllocHandle(SQL_HANDLE_DBC, henv, &hdbc);
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLAllocHandle", SQL_NULL_HANDLE, SQL_NULL_HANDLE);
+        return RaiseErrorFromHandle(0, "SQLAllocHandle", SQL_NULL_HANDLE, SQL_NULL_HANDLE);
 
     //
     // Attributes that must be set before connecting.
@@ -163,7 +163,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, bool fAnsi,
             Py_END_ALLOW_THREADS
             if (!SQL_SUCCEEDED(ret))
             {
-                RaiseErrorFromHandle("SQLSetConnectAttr", hdbc, SQL_NULL_HANDLE);
+                RaiseErrorFromHandle(0, "SQLSetConnectAttr", hdbc, SQL_NULL_HANDLE);
                 Py_BEGIN_ALLOW_THREADS
                 SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
                 Py_END_ALLOW_THREADS
@@ -273,7 +273,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, bool fAnsi,
 
         if (!SQL_SUCCEEDED(ret))
         {
-            RaiseErrorFromHandle("SQLSetConnnectAttr(SQL_ATTR_AUTOCOMMIT)", cnxn->hdbc, SQL_NULL_HANDLE);
+            RaiseErrorFromHandle(cnxn, "SQLSetConnnectAttr(SQL_ATTR_AUTOCOMMIT)", cnxn->hdbc, SQL_NULL_HANDLE);
             Py_DECREF(cnxn);
             return 0;
         }
@@ -287,7 +287,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, bool fAnsi,
 
         if (!SQL_SUCCEEDED(ret))
         {
-            RaiseErrorFromHandle("SQLSetConnnectAttr(SQL_ATTR_ACCESS_MODE)", cnxn->hdbc, SQL_NULL_HANDLE);
+            RaiseErrorFromHandle(cnxn, "SQLSetConnnectAttr(SQL_ATTR_ACCESS_MODE)", cnxn->hdbc, SQL_NULL_HANDLE);
             Py_DECREF(cnxn);
             return 0;
         }
@@ -360,7 +360,7 @@ static PyObject* Connection_set_attr(PyObject* self, PyObject* args)
     Py_END_ALLOW_THREADS
 
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
+        return RaiseErrorFromHandle(cnxn, "SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
     Py_RETURN_NONE;
 }
 
@@ -670,7 +670,7 @@ static PyObject* Connection_getinfo(PyObject* self, PyObject* args)
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
     {
-        RaiseErrorFromHandle("SQLGetInfo", cnxn->hdbc, SQL_NULL_HANDLE);
+        RaiseErrorFromHandle(cnxn, "SQLGetInfo", cnxn->hdbc, SQL_NULL_HANDLE);
         return 0;
     }
 
@@ -723,7 +723,7 @@ PyObject* Connection_endtrans(Connection* cnxn, SQLSMALLINT type)
 
     if (!SQL_SUCCEEDED(ret))
     {
-        RaiseErrorFromHandle("SQLEndTran", hdbc, SQL_NULL_HANDLE);
+        RaiseErrorFromHandle(cnxn, "SQLEndTran", hdbc, SQL_NULL_HANDLE);
         return 0;
     }
 
@@ -815,7 +815,7 @@ static int Connection_setautocommit(PyObject* self, PyObject* value, void* closu
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
     {
-        RaiseErrorFromHandle("SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
+        RaiseErrorFromHandle(cnxn, "SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
         return -1;
     }
 
@@ -841,7 +841,7 @@ static PyObject* Connection_getsearchescape(PyObject* self, void* closure)
         ret = SQLGetInfo(cnxn->hdbc, SQL_SEARCH_PATTERN_ESCAPE, &sz, _countof(sz), &cch);
         Py_END_ALLOW_THREADS
         if (!SQL_SUCCEEDED(ret))
-            return RaiseErrorFromHandle("SQLGetInfo", cnxn->hdbc, SQL_NULL_HANDLE);
+            return RaiseErrorFromHandle(cnxn, "SQLGetInfo", cnxn->hdbc, SQL_NULL_HANDLE);
 
         cnxn->searchescape = PyString_FromStringAndSize(sz, (Py_ssize_t)cch);
     }
@@ -931,7 +931,7 @@ static int Connection_settimeout(PyObject* self, PyObject* value, void* closure)
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
     {
-        RaiseErrorFromHandle("SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
+        RaiseErrorFromHandle(cnxn, "SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
         return -1;
     }
 
@@ -1320,7 +1320,7 @@ static PyObject* Connection_exit(PyObject* self, PyObject* args)
         if (!SQL_SUCCEEDED(ret))
         {
             const char* szFunc = (CompletionType == SQL_COMMIT) ? "SQLEndTran(SQL_COMMIT)" : "SQLEndTran(SQL_ROLLBACK)";
-            return RaiseErrorFromHandle(szFunc, cnxn->hdbc, SQL_NULL_HANDLE);
+            return RaiseErrorFromHandle(cnxn, szFunc, cnxn->hdbc, SQL_NULL_HANDLE);
         }
     }
 

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -1,7 +1,11 @@
 
 #include "pyodbc.h"
+#include "wrapper.h"
+#include "textenc.h"
+#include "connection.h"
 #include "errors.h"
 #include "pyodbcmodule.h"
+#include "sqlwchar.h"
 
 // Exceptions
 
@@ -163,11 +167,11 @@ static PyObject* GetError(const char* sqlstate, PyObject* exc_class, PyObject* p
 
 static const char* DEFAULT_ERROR = "The driver did not supply an error!";
 
-PyObject* RaiseErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt)
+PyObject* RaiseErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc, HSTMT hstmt)
 {
     // The exception is "set" in the interpreter.  This function returns 0 so this can be used in a return statement.
 
-    PyObject* pError = GetErrorFromHandle(szFunction, hdbc, hstmt);
+    PyObject* pError = GetErrorFromHandle(conn, szFunction, hdbc, hstmt);
 
     if (pError)
     {
@@ -179,7 +183,7 @@ PyObject* RaiseErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt)
 }
 
 
-PyObject* GetErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt)
+PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc, HSTMT hstmt)
 {
     TRACE("In RaiseError(%s)!\n", szFunction);
 
@@ -201,8 +205,8 @@ PyObject* GetErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt)
     SQLINTEGER nNativeError;
     SQLSMALLINT cchMsg;
 
-    char sqlstateT[6];
-    char szMsg[1024];
+    ODBCCHAR sqlstateT[6];
+    ODBCCHAR szMsg[1024];
 
     PyObject* pMsg = 0;
     PyObject* pMsgPart = 0;
@@ -237,13 +241,19 @@ PyObject* GetErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt)
 
         SQLRETURN ret;
         Py_BEGIN_ALLOW_THREADS
-        ret = SQLGetDiagRec(nHandleType, h, iRecord, (SQLCHAR*)sqlstateT, &nNativeError, (SQLCHAR*)szMsg, (short)(_countof(szMsg)-1), &cchMsg);
+        ret = SQLGetDiagRecW(nHandleType, h, iRecord, (SQLWCHAR*)sqlstateT, &nNativeError, (SQLWCHAR*)szMsg, (short)(_countof(szMsg)-1), &cchMsg);
         Py_END_ALLOW_THREADS
         if (!SQL_SUCCEEDED(ret))
             break;
 
         // Not always NULL terminated (MS Access)
         sqlstateT[5] = 0;
+
+        // For now, default to UTF-16LE if this is not in the context of a connection.
+        // Note that this will not work if the DM is using a different wide encoding (e.g. UTF-32).
+        const char *unicode_enc = conn ? conn->unicode_enc.name : "utf-16-le";
+        Object msgStr(PyUnicode_Decode((char*)szMsg, cchMsg * sizeof(ODBCCHAR), unicode_enc, "strict"));
+        Object stateStr(PyUnicode_Decode((char*)sqlstateT, 5 * sizeof(ODBCCHAR), unicode_enc, "strict"));
 
         if (cchMsg != 0)
         {
@@ -254,14 +264,14 @@ PyObject* GetErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt)
 
                 memcpy(sqlstate, sqlstateT, sizeof(sqlstate[0]) * _countof(sqlstate));
 
-                pMsg = PyString_FromFormat("[%s] %s (%ld) (%s)", sqlstateT, szMsg, (long)nNativeError, szFunction);
+                pMsg = PyUnicode_FromFormat("[%V] %V (%ld) (%s)", stateStr.Get(), "00000", msgStr.Get(), "(null)", (long)nNativeError, szFunction);
                 if (pMsg == 0)
                     return 0;
             }
             else
             {
                 // This is not the first error message, so append to the existing one.
-                pMsgPart = PyString_FromFormat("; [%s] %s (%ld)", sqlstateT, szMsg, (long)nNativeError);
+                pMsgPart = PyString_FromFormat("; [%V] %V (%ld)", stateStr.Get(), "00000", msgStr.Get(), "(null)", (long)nNativeError);
                 if (pMsgPart == 0)
                 {
                     Py_XDECREF(pMsg);

--- a/src/errors.h
+++ b/src/errors.h
@@ -5,11 +5,14 @@
 // Sets an exception based on the ODBC SQLSTATE and error message and returns zero.  If either handle is not available,
 // pass SQL_NULL_HANDLE.
 //
+// conn
+//   The connection object, from which it will use the Unicode encoding. May be null if not available.
+//
 // szFunction
 //   The name of the function that failed.  Python generates a useful stack trace, but we often don't know where in the
 //   C++ code we failed.
 //
-PyObject* RaiseErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt);
+PyObject* RaiseErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc, HSTMT hstmt);
 
 // Sets an exception using a printf-like error message.
 //
@@ -30,11 +33,14 @@ PyObject* RaiseErrorV(const char* sqlstate, PyObject* exc_class, const char* for
 // used to examine the SQLSTATE using HasSqlState).  If you want to use the error, call PyErr_SetObject(ex->ob_type,
 // ex).  Otherwise, dispose of the error using Py_DECREF(ex).
 //
+// conn
+//   The connection object, from which it will use the Unicode encoding. May be null if not available.
+//
 // szFunction
 //   The name of the function that failed.  Python generates a useful stack trace, but we often don't know where in the
 //   C++ code we failed.
 //
-PyObject* GetErrorFromHandle(const char* szFunction, HDBC hdbc, HSTMT hstmt);
+PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc, HSTMT hstmt);
 
 
 // Returns true if `ex` is a database exception with SQLSTATE `szSqlState`.  Returns false otherwise.

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -121,7 +121,7 @@ static bool ReadVarColumn(Cursor* cur, Py_ssize_t iCol, SQLSMALLINT ctype, bool&
 
         if (!SQL_SUCCEEDED(ret) && ret != SQL_NO_DATA)
         {
-            RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+            RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
             return false;
         }
 
@@ -474,7 +474,7 @@ static PyObject* GetDataBit(Cursor* cur, Py_ssize_t iCol)
     Py_END_ALLOW_THREADS
 
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+        return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
 
     if (cbFetched == SQL_NULL_DATA)
         Py_RETURN_NONE;
@@ -500,7 +500,7 @@ static PyObject* GetDataLong(Cursor* cur, Py_ssize_t iCol)
     ret = SQLGetData(cur->hstmt, (SQLUSMALLINT)(iCol+1), nCType, &value, sizeof(value), &cbFetched);
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+        return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
 
     if (cbFetched == SQL_NULL_DATA)
         Py_RETURN_NONE;
@@ -526,7 +526,7 @@ static PyObject* GetDataLongLong(Cursor* cur, Py_ssize_t iCol)
     Py_END_ALLOW_THREADS
 
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+        return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
 
     if (cbFetched == SQL_NULL_DATA)
         Py_RETURN_NONE;
@@ -548,7 +548,7 @@ static PyObject* GetDataDouble(Cursor* cur, Py_ssize_t iCol)
     ret = SQLGetData(cur->hstmt, (SQLUSMALLINT)(iCol+1), SQL_C_DOUBLE, &value, sizeof(value), &cbFetched);
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+        return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
 
     if (cbFetched == SQL_NULL_DATA)
         Py_RETURN_NONE;
@@ -568,7 +568,7 @@ static PyObject* GetSqlServerTime(Cursor* cur, Py_ssize_t iCol)
     ret = SQLGetData(cur->hstmt, (SQLUSMALLINT)(iCol+1), SQL_C_BINARY, &value, sizeof(value), &cbFetched);
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+        return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
 
     if (cbFetched == SQL_NULL_DATA)
         Py_RETURN_NONE;
@@ -589,7 +589,7 @@ static PyObject* GetUUID(Cursor* cur, Py_ssize_t iCol)
     Py_END_ALLOW_THREADS
 
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+        return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
 
     if (cbFetched == SQL_NULL_DATA)
         Py_RETURN_NONE;
@@ -622,7 +622,7 @@ static PyObject* GetDataTimestamp(Cursor* cur, Py_ssize_t iCol)
     ret = SQLGetData(cur->hstmt, (SQLUSMALLINT)(iCol+1), SQL_C_TYPE_TIMESTAMP, &value, sizeof(value), &cbFetched);
     Py_END_ALLOW_THREADS
     if (!SQL_SUCCEEDED(ret))
-        return RaiseErrorFromHandle("SQLGetData", cur->cnxn->hdbc, cur->hstmt);
+        return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);
 
     if (cbFetched == SQL_NULL_DATA)
         Py_RETURN_NONE;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -670,7 +670,7 @@ bool BindParameter(Cursor* cur, Py_ssize_t index, ParamInfo& info)
 
     if (!SQL_SUCCEEDED(ret))
     {
-        RaiseErrorFromHandle("SQLBindParameter", GetConnection(cur)->hdbc, cur->hstmt);
+        RaiseErrorFromHandle(cur->cnxn, "SQLBindParameter", GetConnection(cur)->hdbc, cur->hstmt);
         return false;
     }
 
@@ -786,7 +786,7 @@ bool PrepareAndBind(Cursor* cur, PyObject* pSql, PyObject* original_params, bool
 
         if (!SQL_SUCCEEDED(ret))
         {
-            RaiseErrorFromHandle(szErrorFunc, GetConnection(cur)->hdbc, cur->hstmt);
+            RaiseErrorFromHandle(cur->cnxn, szErrorFunc, GetConnection(cur)->hdbc, cur->hstmt);
             return false;
         }
 

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -554,7 +554,7 @@ static PyObject* mod_drivers(PyObject* self)
     if (ret != SQL_NO_DATA)
     {
         Py_DECREF(result);
-        return RaiseErrorFromHandle("SQLDrivers", SQL_NULL_HANDLE, SQL_NULL_HANDLE);
+        return RaiseErrorFromHandle(0, "SQLDrivers", SQL_NULL_HANDLE, SQL_NULL_HANDLE);
     }
 
     return result.Detach();
@@ -596,7 +596,7 @@ static PyObject* mod_datasources(PyObject* self)
     if (ret != SQL_NO_DATA)
     {
         Py_DECREF(result);
-        return RaiseErrorFromHandle("SQLDataSources", SQL_NULL_HANDLE, SQL_NULL_HANDLE);
+        return RaiseErrorFromHandle(0, "SQLDataSources", SQL_NULL_HANDLE, SQL_NULL_HANDLE);
     }
 
     return result;


### PR DESCRIPTION
To fix https://github.com/mkleehammer/pyodbc/issues/251 diagnostic messages are retrieved using the Unicode API SQLGetDiagRec**W**. The default is UTF-16LE, as usual for ODBC, but can be configurable when a connection is provided since it is based on connection.unicode_enc.

Due to the amount of duplication I noticed while preparing this fix, in the future it would be good to revisit pyodbc's error handling in general, since a lot of it could be factored out.