### PR TITLE
Fix memory leak in fast executemany()

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1736,6 +1736,7 @@ bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj)
         cur->paramArray = 0;
     }
 
+    Py_XDECREF(rowseq);
     FreeParameterData(cur);
     return ret;
 }


### PR DESCRIPTION
Fix a small but significant memory leak with fast executemany().

You can merge this one to fix the leak, if you are not ready to accept the parameter array refactoring.