### PR TITLE
test_drivers tweak for sqlservertests

### DIFF
--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1513,7 +1513,7 @@ class SqlServerTestCase(unittest.TestCase):
     def test_drivers(self):
         drivers = pyodbc.drivers()
         self.assertEqual(list, type(drivers))
-        self.assert_(len(drivers) > 1)
+        self.assert_(len(drivers) > 0)
 
         m = re.search('DRIVER={([^}]+)}', self.connection_string, re.IGNORECASE)
         current = m.group(1)

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1341,7 +1341,7 @@ class SqlServerTestCase(unittest.TestCase):
     def test_drivers(self):
         drivers = pyodbc.drivers()
         self.assertEqual(list, type(drivers))
-        self.assert_(len(drivers) > 1)
+        self.assert_(len(drivers) > 0)
 
         m = re.search('DRIVER={([^}]+)}', self.connection_string, re.IGNORECASE)
         current = m.group(1)


### PR DESCRIPTION
`test_drivers` fails on my Linux test VM because I only have one ODBC driver installed ("ODBC Driver 13 for SQL Server"). There is no real need for more than one driver to be installed.