### PR TITLE
Fix use of Unicode connection string in Python2

### DIFF
--- a/src/cnxninfo.cpp
+++ b/src/cnxninfo.cpp
@@ -46,6 +46,14 @@ static PyObject* GetHash(PyObject* p)
     if (!bytes)
         return 0;
     p = bytes.Get();
+#else
+    Object bytes(PyUnicode_Check(p) ? PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(p), PyUnicode_GET_SIZE(p), 0) : 0);
+    if (PyUnicode_Check(p))
+    {
+        if (!bytes)
+            return 0;
+        p = bytes.Get();
+    }
 #endif
 
     Object hash(PyObject_CallMethod(hashlib, "new", "s", "sha1"));


### PR DESCRIPTION
If a Unicode connection string is used, hash.update throws an exception about invalid encoding.