### PR TITLE
Use correct size for SQL_ATTR_NOSCAN attribute

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -2043,10 +2043,10 @@ static PyObject* Cursor_getnoscan(PyObject* self, void *closure)
     if (!cursor)
         return 0;
 
-    SQLUINTEGER noscan = SQL_NOSCAN_OFF;
+    SQLULEN noscan = SQL_NOSCAN_OFF;
     SQLRETURN ret;
     Py_BEGIN_ALLOW_THREADS
-    ret = SQLGetStmtAttr(cursor->hstmt, SQL_ATTR_NOSCAN, (SQLPOINTER)&noscan, sizeof(SQLUINTEGER), 0);
+    ret = SQLGetStmtAttr(cursor->hstmt, SQL_ATTR_NOSCAN, (SQLPOINTER)&noscan, sizeof(SQLULEN), 0);
     Py_END_ALLOW_THREADS
 
     if (!SQL_SUCCEEDED(ret))


### PR DESCRIPTION
Prevents the buffer from overflowing (and crashing Python).

From https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetstmtattr-function

"SQL_ATTR_NOSCAN (ODBC 1.0) An **SQLULEN** value that indicates whether the driver should scan SQL strings for escape sequences"
