### PR TITLE
Fix spelling in error message

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -281,7 +281,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, bool fAnsi,
 
         if (!SQL_SUCCEEDED(ret))
         {
-            RaiseErrorFromHandle(cnxn, "SQLSetConnnectAttr(SQL_ATTR_AUTOCOMMIT)", cnxn->hdbc, SQL_NULL_HANDLE);
+            RaiseErrorFromHandle(cnxn, "SQLSetConnectAttr(SQL_ATTR_AUTOCOMMIT)", cnxn->hdbc, SQL_NULL_HANDLE);
             Py_DECREF(cnxn);
             return 0;
         }
@@ -295,7 +295,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, bool fAnsi,
 
         if (!SQL_SUCCEEDED(ret))
         {
-            RaiseErrorFromHandle(cnxn, "SQLSetConnnectAttr(SQL_ATTR_ACCESS_MODE)", cnxn->hdbc, SQL_NULL_HANDLE);
+            RaiseErrorFromHandle(cnxn, "SQLSetConnectAttr(SQL_ATTR_ACCESS_MODE)", cnxn->hdbc, SQL_NULL_HANDLE);
             Py_DECREF(cnxn);
             return 0;
         }


### PR DESCRIPTION
In `RaiseErrorFromHandle`, the spelling in the message was "SQLSetConnnectAttr". I changed the spelling to "SQLSetConnectAttr". Note, I have not run this locally. I was just browsing the repo when I noticed, so I thought a PR couldn't hurt. Please disregard if there is some reason for the current spelling.