### PR TITLE
tests: remove requirement that driver name be in curly brackets

### DIFF
--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -1214,7 +1214,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(list, type(drivers))
         self.assertTrue(len(drivers) > 1)
 
-        m = re.search('DRIVER={([^}]+)}', self.connection_string, re.IGNORECASE)
+        m = re.search('DRIVER={?([^}]+?)}?;', self.connection_string, re.IGNORECASE)
         current = m.group(1)
         self.assertTrue(current in drivers)
             

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1526,7 +1526,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(list, type(drivers))
         self.assertTrue(len(drivers) > 0)
 
-        m = re.search('DRIVER={([^}]+)}', self.connection_string, re.IGNORECASE)
+        m = re.search('DRIVER={?([^}]+?)}?;', self.connection_string, re.IGNORECASE)
         current = m.group(1)
         self.assertTrue(current in drivers)
 

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -1214,7 +1214,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(list, type(drivers))
         self.assertTrue(len(drivers) > 1)
 
-        m = re.search('DRIVER={([^}]+)}', self.connection_string, re.IGNORECASE)
+        m = re.search('DRIVER={?([^}]+?)}?;', self.connection_string, re.IGNORECASE)
         current = m.group(1)
         self.assertTrue(current in drivers)
             

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1363,7 +1363,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(list, type(drivers))
         self.assertTrue(len(drivers) > 0)
 
-        m = re.search('DRIVER={([^}]+)}', self.connection_string, re.IGNORECASE)
+        m = re.search('DRIVER={?([^}]+?)}?;', self.connection_string, re.IGNORECASE)
         current = m.group(1)
         self.assertTrue(current in drivers)
 


### PR DESCRIPTION
It is a common misconception that `DRIVER=` names must be enclosed in curly brackets, e.g.,

```
DRIVER={ODBC Driver 17 for SQL Server}
```

In fact

```
DRIVER=ODBC Driver 17 for SQL Server
```

is perfectly legal. These tweaks allow either form to be used in connection strings for tests.