### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def main():
         'maintainer':       "Michael Kleehammer",
         'maintainer_email': "michael@kleehammer.com",
 
-        'ext_modules': [Extension('pyodbc', files, **settings)],
+        'ext_modules': [Extension('pyodbc', sorted(files), **settings)],
 
         'license': 'MIT',
 


### PR DESCRIPTION
so that pyodbc.so builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.