### PR TITLE
Support for IBM DB2 DECFLOAT type (-360)

### DIFF
--- a/src/dbspecific.h
+++ b/src/dbspecific.h
@@ -12,6 +12,7 @@
 
 
 #define SQL_SS_XML -152         // SQL Server 2005 XML type
+#define SQL_DB2_DECFLOAT -360   // IBM DB/2 DECFLOAT type
 #define SQL_DB2_XML -370        // IBM DB/2 XML type
 #define SQL_SS_TIME2 -154       // SQL Server 2008 time type
 

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -814,6 +814,7 @@ PyObject* GetData(Cursor* cur, Py_ssize_t iCol)
 
     case SQL_DECIMAL:
     case SQL_NUMERIC:
+    case SQL_DB2_DECFLOAT:
         return GetDataDecimal(cur, iCol);
 
     case SQL_BIT:


### PR DESCRIPTION
The [DECFLOAT](https://www.ibm.com/developerworks/data/library/techarticle/dm-0801chainani/index.html) type supports both 16 and 34 digits of precision. I tested these by creating the following table in DB2:

```
CREATE TABLE DB2INST1.DECFLOAT_TEST (
	COLUMN1 DECFLOAT(34),
	COLUMN2 DECFLOAT(16)
);

INSERT INTO DB2INST1.DECFLOAT_TEST VALUES (9.999999999999999999999999999999, 9.999999999999999);
```

I utilized the following test program:

```
import pyodbc

def main():
    c = pyodbc.connect('DSN=SAMPLE; UID=db2inst1; PWD=secret')

    cursor = c.cursor()
    cursor.execute('select column1, column2 from decfloat_test')
    row = cursor.fetchone()
    print(row)

if __name__ == '__main__':
    main()
```

Without this change, I get the following error:

```
Traceback (most recent call last):
  File "/home/cody/PycharmProjects/decfloat/test.py", line 12, in <module>
    main()
  File "/home/cody/PycharmProjects/decfloat/test.py", line 8, in main
    row = cursor.fetchone()
pyodbc.ProgrammingError: ('ODBC SQL type -360 is not yet supported.  column-index=0  type=-360', 'HY106')
```

With it, I can successfully select the two values with both Python 2.7 and 3.5:

```(Decimal('9.999999999999999999999999999999'), Decimal('9.999999999999999'))```
