### PR TITLE
Test for issue 506

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1813,12 +1813,14 @@ bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj)
                     // "schema change" or conversion error. Try again on next batch.
                     rowptr--;
                     Py_XDECREF(colseq);
+                    colseq = 0;
                     // Finish this batch of rows and attempt to execute before starting another.
                     goto DoExecute;
                 }
             }
             rows_converted++;
             Py_XDECREF(colseq);
+            colseq = 0;
             r++;
             if ( r >= rowcount )
             {

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1583,6 +1583,26 @@ class SqlServerTestCase(unittest.TestCase):
         assert row.type_name == 'varchar'
         assert row.column_size == 4, row.column_size
 
+        # <test null termination fix (issue #506)>
+        for i in range(8, 16):
+            table_name = 'pyodbc_89abcdef'[:i]
+
+            self.cursor.execute("""\
+            BEGIN TRY
+                DROP TABLE {0};
+            END TRY
+            BEGIN CATCH
+            END CATCH
+            CREATE TABLE {0} (id INT PRIMARY KEY);
+            """.format(table_name))
+
+            col_count = len([col.column_name for col in self.cursor.columns(table_name)])
+            # print('table [{}] ({} characters): {} columns{}'.format(table_name, i, col_count, ' <-' if col_count == 0 else ''))
+            self.assertEqual(col_count, 1)
+
+            self.cursor.execute("DROP TABLE {};".format(table_name))
+        # </test null termination fix (issue #506)>
+
     def test_cancel(self):
         # I'm not sure how to reliably cause a hang to cancel, so for now we'll settle with
         # making sure SQLCancel is called correctly.


### PR DESCRIPTION
SQL Server test for #506 under Python 3. Originally tested against current master (d5a8a7b) where the test consistently failed, then merged in 506-unicode (3cb443a) and confirmed that the test consistently passed.