### PR TITLE
Fix UTF-16 conversion issues for connection errors on big endian

### DIFF
--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -289,9 +289,9 @@ PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc
         // Not always NULL terminated (MS Access)
         sqlstateT[5] = 0;
 
-        // For now, default to UTF-16LE if this is not in the context of a connection.
+        // For now, default to UTF-16 if this is not in the context of a connection.
         // Note that this will not work if the DM is using a different wide encoding (e.g. UTF-32).
-        const char *unicode_enc = conn ? conn->metadata_enc.name : "utf-16-le";
+        const char *unicode_enc = conn ? conn->metadata_enc.name : ENCSTR_UTF16NE;
         Object msgStr(PyUnicode_Decode((char*)szMsg, cchMsg * sizeof(ODBCCHAR), unicode_enc, "strict"));
 
         if (cchMsg != 0 && msgStr.Get())


### PR DESCRIPTION
In #255, the code was changed to use the native endianness of the
system, but when a connection failure occurs the encoding was still
hard-coded to utf-16-le which causes mojibake on big endian systems.

Instead use ENCSTR_UTF16NE, which will be either utf-16-le or
utf-16-be, depending on the native endian for the system.

Fixes #563