### PR TITLE
Bind 32-bit ints correctly on big endian LP64 systems

### DIFF
--- a/src/cursor.h
+++ b/src/cursor.h
@@ -72,7 +72,7 @@ struct ParamInfo
     union
     {
         unsigned char ch;
-        long l;
+        int i32;
         INT64 i64;
         double dbl;
         TIMESTAMP_STRUCT timestamp;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -880,11 +880,11 @@ static bool GetIntInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo
     }
     else
     {
-        info.Data.l = PyLong_AsLong(param);
+        info.Data.i32 = PyLong_AsLong(param);
 
         info.ValueType         = SQL_C_LONG;
         info.ParameterType     = SQL_INTEGER;
-        info.ParameterValuePtr = &info.Data.l;
+        info.ParameterValuePtr = &info.Data.i32;
         info.StrLen_or_Ind     = 4;
     }
 
@@ -909,11 +909,11 @@ static bool GetLongInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInf
     }
     else
     {
-        info.Data.l = PyLong_AsLong(param);
+        info.Data.i32 = PyLong_AsLong(param);
 
         info.ValueType         = SQL_C_LONG;
         info.ParameterType     = SQL_INTEGER;
-        info.ParameterValuePtr = &info.Data.l;
+        info.ParameterValuePtr = &info.Data.i32;
         info.StrLen_or_Ind     = 4;
     }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -880,7 +880,7 @@ static bool GetIntInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo
     }
     else
     {
-        info.Data.i32 = PyLong_AsLong(param);
+        info.Data.i32 = (int)PyLong_AsLong(param);
 
         info.ValueType         = SQL_C_LONG;
         info.ParameterType     = SQL_INTEGER;
@@ -909,7 +909,7 @@ static bool GetLongInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInf
     }
     else
     {
-        info.Data.i32 = PyLong_AsLong(param);
+        info.Data.i32 = (int)PyLong_AsLong(param);
 
         info.ValueType         = SQL_C_LONG;
         info.ParameterType     = SQL_INTEGER;


### PR DESCRIPTION
The size of a long on 64-bit Linux, Unix, and other LP64 platforms
is 64-bit, so passing the address of it and saying it is a 32-bit
integer will result in only the top 4 bytes being read. While this
does work on little endian systems, on big endian systems these bytes
will always be 0 for values < INT_MAX.

Instead, change the type to be an int, which should be 32 bits on
all supported platforms.