### PR TITLE
Add test_emoticons_as_literal to sqlservertests.py

### DIFF
--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -470,7 +470,10 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.executemany(sql, params)
         self.assertEqual(self.cursor.execute("SELECT CAST(dt2 AS VARCHAR) FROM ##issue540").fetchval(), '2019-03-12 10:00:00.12')
 
-    def test_high_unicode(self):
+    def test_fast_executemany_high_unicode(self):
+        if self.handle_known_issues_for('freetds', print_reminder=True):
+            warn('FREETDS_KNOWN_ISSUE - test_fast_executemany_high_unicode: test cancelled.')
+            return
         v = u"🎥"
         self.cursor.fast_executemany = True
         self.cursor.execute("CREATE TABLE t1 (col1 nvarchar(max) null)")

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1719,10 +1719,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(result, v)
 
     def test_emoticons_as_literal(self):
-        # https://github.com/mkleehammer/pyodbc/issues/423
-        #
-        # When sending a varchar parameter, pyodbc is supposed to set ColumnSize to the number
-        # of characters.  Ensure it works even with 4-byte characters.
+        # similar to `test_emoticons_as_parameter`, above, except for Unicode literal
         #
         # http://www.fileformat.info/info/unicode/char/1f31c/index.htm
 

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1701,7 +1701,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values ('one')")
         self.assertRaises(pyodbc.IntegrityError, self.cursor.execute, "insert into t1 values ('one')")
 
-    def test_emoticons(self):
+    def test_emoticons_as_parameter(self):
         # https://github.com/mkleehammer/pyodbc/issues/423
         #
         # When sending a varchar parameter, pyodbc is supposed to set ColumnSize to the number
@@ -1713,6 +1713,23 @@ class SqlServerTestCase(unittest.TestCase):
 
         self.cursor.execute("create table t1(s varchar(100))")
         self.cursor.execute("insert into t1 values (?)", v)
+
+        result = self.cursor.execute("select s from t1").fetchone()[0]
+
+        self.assertEqual(result, v)
+
+    def test_emoticons_as_literal(self):
+        # https://github.com/mkleehammer/pyodbc/issues/423
+        #
+        # When sending a varchar parameter, pyodbc is supposed to set ColumnSize to the number
+        # of characters.  Ensure it works even with 4-byte characters.
+        #
+        # http://www.fileformat.info/info/unicode/char/1f31c/index.htm
+
+        v = "x \U0001F31C z"
+
+        self.cursor.execute("create table t1(s varchar(100))")
+        self.cursor.execute("insert into t1 values (N'%s')" % v)
 
         result = self.cursor.execute("select s from t1").fetchone()[0]
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1635,6 +1635,7 @@ class SqlServerTestCase(unittest.TestCase):
         # of characters.  Ensure it works even with 4-byte characters.
         #
         # http://www.fileformat.info/info/unicode/char/1f31c/index.htm
+
         v = "x \U0001F31C z"
 
         self.cursor.execute("create table t1(s nvarchar(100))")
@@ -1645,12 +1646,10 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(result, v)
 
     def test_emoticons_as_literal(self):
-        # https://github.com/mkleehammer/pyodbc/issues/423
-        #
-        # When sending a varchar parameter, pyodbc is supposed to set ColumnSize to the number
-        # of characters.  Ensure it works even with 4-byte characters.
+        # similar to `test_emoticons_as_parameter`, above, except for Unicode literal
         #
         # http://www.fileformat.info/info/unicode/char/1f31c/index.htm
+
         v = "x \U0001F31C z"
 
         self.cursor.execute("create table t1(s nvarchar(100))")

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1628,7 +1628,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("select 1")
         self.cursor.cancel()
 
-    def test_emoticons(self):
+    def test_emoticons_as_parameter(self):
         # https://github.com/mkleehammer/pyodbc/issues/423
         #
         # When sending a varchar parameter, pyodbc is supposed to set ColumnSize to the number
@@ -1639,6 +1639,22 @@ class SqlServerTestCase(unittest.TestCase):
 
         self.cursor.execute("create table t1(s nvarchar(100))")
         self.cursor.execute("insert into t1 values (?)", v)
+
+        result = self.cursor.execute("select s from t1").fetchone()[0]
+
+        self.assertEqual(result, v)
+
+    def test_emoticons_as_literal(self):
+        # https://github.com/mkleehammer/pyodbc/issues/423
+        #
+        # When sending a varchar parameter, pyodbc is supposed to set ColumnSize to the number
+        # of characters.  Ensure it works even with 4-byte characters.
+        #
+        # http://www.fileformat.info/info/unicode/char/1f31c/index.htm
+        v = "x \U0001F31C z"
+
+        self.cursor.execute("create table t1(s nvarchar(100))")
+        self.cursor.execute("insert into t1 values (N'%s')" % v)
 
         result = self.cursor.execute("select s from t1").fetchone()[0]
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -87,7 +87,7 @@ class SqlServerTestCase(unittest.TestCase):
         elif type_name == 'freetds':
             return ('tdsodbc' in driver_name)
 
-    def handle_known_issues_for(self, type_name, print_reminder=False):
+    def handle_known_issues_for(self, type_name, print_reminder=False, failure_crashes_python=False):
         """
         Checks driver `type_name` and "killswitch" variable `handle_known_issues` to see if
         known issue handling should be bypassed. Optionally prints a reminder message to
@@ -115,7 +115,7 @@ class SqlServerTestCase(unittest.TestCase):
                 raise
         """
         if self.driver_type_is(type_name):
-            if handle_known_issues:
+            if handle_known_issues or failure_crashes_python:
                 return True
             else:
                 if print_reminder:
@@ -438,7 +438,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(rows[0][0], v)
 
     def test_fast_executemany_to_local_temp_table(self):
-        if self.handle_known_issues_for('freetds', print_reminder=True):
+        if self.handle_known_issues_for('freetds', print_reminder=True, failure_crashes_python=True):
             warn('FREETDS_KNOWN_ISSUE - test_fast_executemany_to_local_temp_table: test cancelled.')
             return 
         v = 'Ώπα'
@@ -451,7 +451,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(self.cursor.execute("SELECT txt FROM #issue295").fetchval(), v)
 
     def test_fast_executemany_to_datetime2(self):
-        if self.handle_known_issues_for('freetds', print_reminder=True):
+        if self.handle_known_issues_for('freetds', print_reminder=True, failure_crashes_python=True):
             warn('FREETDS_KNOWN_ISSUE - test_fast_executemany_to_datetime2: test cancelled.')
             return
         v = datetime(2019, 3, 12, 10, 0, 0, 123456)
@@ -463,7 +463,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(self.cursor.execute("SELECT CAST(dt2 AS VARCHAR) FROM ##issue540").fetchval(), '2019-03-12 10:00:00.12')
 
     def test_fast_executemany_high_unicode(self):
-        if self.handle_known_issues_for('freetds', print_reminder=True):
+        if self.handle_known_issues_for('freetds', print_reminder=True, failure_crashes_python=True):
             warn('FREETDS_KNOWN_ISSUE - test_fast_executemany_high_unicode: test cancelled.')
             return
         v = "🎥"

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -462,7 +462,10 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.executemany(sql, params)
         self.assertEqual(self.cursor.execute("SELECT CAST(dt2 AS VARCHAR) FROM ##issue540").fetchval(), '2019-03-12 10:00:00.12')
 
-    def test_high_unicode(self):
+    def test_fast_executemany_high_unicode(self):
+        if self.handle_known_issues_for('freetds', print_reminder=True):
+            warn('FREETDS_KNOWN_ISSUE - test_fast_executemany_high_unicode: test cancelled.')
+            return
         v = "🎥"
         self.cursor.fast_executemany = True
         self.cursor.execute("CREATE TABLE t1 (col1 nvarchar(max) null)")
@@ -1649,6 +1652,11 @@ class SqlServerTestCase(unittest.TestCase):
         # similar to `test_emoticons_as_parameter`, above, except for Unicode literal
         #
         # http://www.fileformat.info/info/unicode/char/1f31c/index.htm
+
+        if self.handle_known_issues_for('freetds', print_reminder=True):
+            warn('FREETDS_KNOWN_ISSUE - test_emoticons_as_literal: test cancelled.')
+            # https://github.com/FreeTDS/freetds/issues/317
+            return
 
         v = "x \U0001F31C z"
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -25,7 +25,7 @@ is installed:
   2005: DRIVER={SQL Server}
   2008: DRIVER={SQL Server Native Client 10.0}
   
-If using FreeTDS ODBC, be sure to use version 1.00.97 or newer.
+If using FreeTDS ODBC, be sure to use version 1.1.23 or newer.
 """
 
 import sys, os, re, uuid
@@ -1653,10 +1653,8 @@ class SqlServerTestCase(unittest.TestCase):
         #
         # http://www.fileformat.info/info/unicode/char/1f31c/index.htm
 
-        if self.handle_known_issues_for('freetds', print_reminder=True):
-            warn('FREETDS_KNOWN_ISSUE - test_emoticons_as_literal: test cancelled.')
-            # https://github.com/FreeTDS/freetds/issues/317
-            return
+        # FreeTDS ODBC issue fixed in version 1.1.23
+        # https://github.com/FreeTDS/freetds/issues/317
 
         v = "x \U0001F31C z"
 


### PR DESCRIPTION
Ensure correct handling of supplementary characters in `N'...'` literals.