### PR TITLE
Build Linux wheels on Travis with cibuildwheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
-sudo: false
+
+matrix:
+  include:
+  - sudo: required
+    services:
+      - docker
+    env: PIP=pip
+
 python:
   - "2.7"
   - "3.4"
@@ -15,7 +22,17 @@ addons:
     - g++-4.8
     - unixodbc-dev
 
+env:
+  global:
+  - CIBW_BEFORE_BUILD="yum -y install unixODBC-devel"
+
 install:
   - python setup.py install
 
-script: true
+script:
+  - $PIP install cibuildwheel==1.1.0
+  - cibuildwheel --output-dir wheelhouse
+  - python -m pip install twine
+
+after_success:
+  - python -m twine upload --skip-existing wheelhouse/*.whl


### PR DESCRIPTION
I ran into #175 and thought I'd try fixing it by building Linux wheels directly on Travis CI using `cibuildwheel`. I tried this out in a fork and I believe it works.

You would have to add your `TWINE_USERNAME` and `TWINE_PASSWORD` as (encrypted) environment variables [in the repository settings](https://github.com/mkleehammer/pyodbc/settings/secrets).

I added the PyPI upload as `after_success`, so it will not affect the build status if there is a problem with the upload, unless there is a timeout (which happens when the environment vaiables are not set).

The only remaining problem I encountered is that PyPI reports
```
HTTPError: 400 Client Error: '4.0.29b9+commitf5ea676' is an invalid value for Version.
Error: Can't use PEP 440 local versions.
See https://packaging.python.org/specifications/core-metadata
for url: https://test.pypi.org/legacy/
```

But I believe this only happens when pushing a wheel for an untagged commit, which is anyway something one doesn't want.