### PR TITLE
Add a note about C++ compilers to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The easiest way to install is to use pip:
 
 Precompiled binary wheels are provided for most Python versions on Windows and macOS.  On other
 operating systems this will build from source.  Note, pyodbc contains C++ extensions so you will
-need a suitable C++ compiler on your computer to install pyodbc, on all operating systems.  See
-the [documentation](https://github.com/mkleehammer/pyodbc/wiki/Install) for details.
+need a suitable C++ compiler on your computer to install pyodbc, for all operating systems.  See
+the [docs](https://github.com/mkleehammer/pyodbc/wiki/Install) for details.
 
 [Documentation](https://github.com/mkleehammer/pyodbc/wiki)
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ packed with even more Pythonic convenience.
 The easiest way to install is to use pip:
 
     pip install pyodbc
-    
+
 Precompiled binary wheels are provided for most Python versions on Windows and macOS.  On other
-operating systems this will build from source.
+operating systems this will build from source.  Note, pyodbc contains C++ extensions so you will
+need a suitable C++ compiler on your computer to install pyodbc, on all operating systems.  See
+the [documentation](https://github.com/mkleehammer/pyodbc/wiki/Install) for details.
 
 [Documentation](https://github.com/mkleehammer/pyodbc/wiki)
 
 [Release Notes](https://github.com/mkleehammer/pyodbc/releases)
-


### PR DESCRIPTION
This updates the README text to include the need for a suitable C++ compiler when installing pyodbc, and a reference to the appropriate wiki page as well.  Hopefully this will help people when installing pyodbc for the first time.