### PR TITLE
Compile for venv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ def get_compiler_settings(version_str):
         dirs = [item.path for item in os.scandir('/usr/include')
                 if item.name.startswith('python') and item.is_dir()]
         settings['include_dirs'].extend(dirs)
-        
+
         cflags = os.popen('odbc_config --cflags 2>/dev/null').read().strip()
         if cflags:
             settings['extra_compile_args'].extend(cflags.split())

--- a/setup.py
+++ b/setup.py
@@ -193,6 +193,11 @@ def get_compiler_settings(version_str):
         # Python functions take a lot of 'char *' that really should be const.  gcc complains about this *a lot*
         settings['extra_compile_args'].append('-Wno-write-strings')
 
+        # For VENV to locate headers
+        dirs = [item.path for item in os.scandir('/usr/include')
+                if item.name.startswith('python') and item.is_dir()]
+        settings['include_dirs'].extend(dirs)
+        
         cflags = os.popen('odbc_config --cflags 2>/dev/null').read().strip()
         if cflags:
             settings['extra_compile_args'].extend(cflags.split())


### PR DESCRIPTION
Installing the package into virtual environment fails due to missing headers in POSIX systems where compilation is necessary. This will include path where headers are stored as installed by ibpython3.X-dev module