### PR TITLE
SQL Server test_columns() test failing

### DIFF
--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1610,11 +1610,7 @@ class SqlServerTestCase(unittest.TestCase):
             table_name = 'pyodbc_89abcdef'[:i]
 
             self.cursor.execute("""\
-            BEGIN TRY
-                DROP TABLE {0};
-            END TRY
-            BEGIN CATCH
-            END CATCH
+            IF OBJECT_ID (N'{0}', N'U') IS NOT NULL DROP TABLE {0};
             CREATE TABLE {0} (id INT PRIMARY KEY);
             """.format(table_name))
 


### PR DESCRIPTION
I'm getting an error when running the `tests3\sqlservertests.py` script.  It seems to be because a table is being dropped within a TRY..CATCH block.  Doing so can introduce complications around transaction management.  The error I'm getting is:
```
======================================================================
ERROR: test_columns (__main__.SqlServerTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests3\sqlservertests.py", line 1612, in test_columns
    self.cursor.execute("""\
pyodbc.ProgrammingError: ('42000', '[42000] [Microsoft][SQL Server Native Client 10.0][SQL Server]The current transaction cannot be committed and cannot support operations that write to the log file. Roll back the transaction. (3930) (SQLExecDirectW)')
----------------------------------------------------------------------
```
It's true I'm using a relatively old driver against SQL Server 2008R2.  Nevertheless, I'm not sure the TRY..CATCH block is strictly needed for this test.  If @gordthompson doesn't object (see his PR #518) I'd like to change the code slightly, to check for the existence of the table with `OBJECT_ID()` before dropping it.  That way, this test should (hopefully) work on all SQL Server combinations.