### PR TITLE
Return an exit code from each test script

### DIFF
--- a/tests2/accesstests.py
+++ b/tests2/accesstests.py
@@ -659,10 +659,12 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
     # Add the build directory to the path so we're testing the latest build, not the installed version.
     add_to_path()
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/dbapitests.py
+++ b/tests2/dbapitests.py
@@ -1,4 +1,4 @@
-
+import sys
 import unittest
 from testutils import *
 import dbapi20
@@ -38,6 +38,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=(options.verbose > 1) and 9 or 0)
     result = testRunner.run(suite)
 
+    return result
+
+
 if __name__ == '__main__':
-    main()
-    
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/exceltests.py
+++ b/tests2/exceltests.py
@@ -131,10 +131,12 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
     # Add the build directory to the path so we're testing the latest build, not the installed version.
     add_to_path()
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -254,7 +254,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', 'รก')
+        self._test_strtype('varchar', 'แ')
 
     #
     # unicode
@@ -272,7 +272,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_unicode_%s' % len(value)] = _maketest(value)
 
     def test_unicode_upperlatin(self):
-        self._test_strtype('varchar', 'รก')
+        self._test_strtype('varchar', 'แ')
 
     #
     # binary
@@ -309,7 +309,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_image_%s' % len(value)] = _maketest(value)
 
     def test_image_upperlatin(self):
-        self._test_strliketype('image', buffer('รก'))
+        self._test_strliketype('image', buffer('แ'))
 
     #
     # text
@@ -330,7 +330,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strliketype('text', 'รก')
+        self._test_strliketype('text', 'แ')
 
     #
     # bit

--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -254,7 +254,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', 'á')
+        self._test_strtype('varchar', 'ï¿½')
 
     #
     # unicode
@@ -272,7 +272,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_unicode_%s' % len(value)] = _maketest(value)
 
     def test_unicode_upperlatin(self):
-        self._test_strtype('varchar', 'á')
+        self._test_strtype('varchar', 'ï¿½')
 
     #
     # binary
@@ -309,7 +309,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_image_%s' % len(value)] = _maketest(value)
 
     def test_image_upperlatin(self):
-        self._test_strliketype('image', buffer('á'))
+        self._test_strliketype('image', buffer('ï¿½'))
 
     #
     # text
@@ -330,7 +330,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strliketype('text', 'á')
+        self._test_strliketype('text', 'ï¿½')
 
     #
     # bit
@@ -1261,6 +1261,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -1269,4 +1271,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -254,7 +254,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', '�')
+        self._test_strtype('varchar', 'á')
 
     #
     # unicode
@@ -272,7 +272,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_unicode_%s' % len(value)] = _maketest(value)
 
     def test_unicode_upperlatin(self):
-        self._test_strtype('varchar', '�')
+        self._test_strtype('varchar', 'á')
 
     #
     # binary
@@ -309,7 +309,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_image_%s' % len(value)] = _maketest(value)
 
     def test_image_upperlatin(self):
-        self._test_strliketype('image', buffer('�'))
+        self._test_strliketype('image', buffer('á'))
 
     #
     # text
@@ -330,7 +330,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strliketype('text', '�')
+        self._test_strliketype('text', 'á')
 
     #
     # bit

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -222,7 +222,7 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', u'á', colsize=3)
+        self._test_strtype('varchar', u'ï¿½', colsize=3)
 
     #
     # binary
@@ -259,7 +259,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_blob_%s' % len(value)] = _maketest(value)
 
     def test_blob_upperlatin(self):
-        self._test_strtype('blob', bytearray('á'))
+        self._test_strtype('blob', bytearray('ï¿½'))
 
     #
     # text
@@ -277,7 +277,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('text', u'á')
+        self._test_strtype('text', u'ï¿½')
 
     #
     # unicode
@@ -748,6 +748,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -756,4 +758,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -222,7 +222,7 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', u'�', colsize=3)
+        self._test_strtype('varchar', u'á', colsize=3)
 
     #
     # binary
@@ -259,7 +259,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_blob_%s' % len(value)] = _maketest(value)
 
     def test_blob_upperlatin(self):
-        self._test_strtype('blob', bytearray('�'))
+        self._test_strtype('blob', bytearray('á'))
 
     #
     # text
@@ -277,7 +277,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('text', u'�')
+        self._test_strtype('text', u'á')
 
     #
     # unicode

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -222,7 +222,7 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', u'รก', colsize=3)
+        self._test_strtype('varchar', u'แ', colsize=3)
 
     #
     # binary
@@ -259,7 +259,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_blob_%s' % len(value)] = _maketest(value)
 
     def test_blob_upperlatin(self):
-        self._test_strtype('blob', bytearray('รก'))
+        self._test_strtype('blob', bytearray('แ'))
 
     #
     # text
@@ -277,7 +277,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('text', u'รก')
+        self._test_strtype('text', u'แ')
 
     #
     # unicode

--- a/tests2/pgtests.py
+++ b/tests2/pgtests.py
@@ -571,6 +571,9 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(s)
 
+    return result
+
+
 if __name__ == '__main__':
 
     # Add the build directory to the path so we're testing the latest build, not the installed version.
@@ -578,4 +581,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/sqldwtests.py
+++ b/tests2/sqldwtests.py
@@ -1485,6 +1485,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -1493,4 +1495,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/sqlitetests.py
+++ b/tests2/sqlitetests.py
@@ -203,7 +203,7 @@ class SqliteTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('varchar', u'รก')
+        self._test_strtype('varchar', u'แ')
 
     #
     # blob

--- a/tests2/sqlitetests.py
+++ b/tests2/sqlitetests.py
@@ -203,7 +203,7 @@ class SqliteTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('varchar', u'á')
+        self._test_strtype('varchar', u'ï¿½')
 
     #
     # blob
@@ -709,7 +709,7 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
-    sys.exit(result.errors and 1 or 0)
+    return result
 
 
 if __name__ == '__main__':
@@ -719,4 +719,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests2/sqlitetests.py
+++ b/tests2/sqlitetests.py
@@ -203,7 +203,7 @@ class SqliteTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('varchar', u'�')
+        self._test_strtype('varchar', u'á')
 
     #
     # blob

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1879,6 +1879,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -1887,4 +1889,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/accesstests.py
+++ b/tests3/accesstests.py
@@ -616,10 +616,12 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
     # Add the build directory to the path so we're testing the latest build, not the installed version.
     add_to_path()
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/dbapitests.py
+++ b/tests3/dbapitests.py
@@ -1,4 +1,4 @@
-
+import sys
 import unittest
 from testutils import *
 import dbapi20
@@ -38,6 +38,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=(options.verbose > 1) and 9 or 0)
     result = testRunner.run(suite)
 
+    return result
+
+
 if __name__ == '__main__':
-    main()
-    
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/exceltests.py
+++ b/tests3/exceltests.py
@@ -131,10 +131,12 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
     # Add the build directory to the path so we're testing the latest build, not the installed version.
     add_to_path()
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -254,7 +254,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', 'รก')
+        self._test_strtype('varchar', 'แ')
 
     #
     # unicode
@@ -272,7 +272,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_unicode_%s' % len(value)] = _maketest(value)
 
     def test_unicode_upperlatin(self):
-        self._test_strtype('varchar', 'รก')
+        self._test_strtype('varchar', 'แ')
 
     #
     # binary
@@ -309,7 +309,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_image_%s' % len(value)] = _maketest(value)
 
     def test_image_upperlatin(self):
-        self._test_strliketype('image', buffer('รก'))
+        self._test_strliketype('image', buffer('แ'))
 
     #
     # text
@@ -330,7 +330,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strliketype('text', 'รก')
+        self._test_strliketype('text', 'แ')
 
     #
     # bit

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -254,7 +254,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', 'á')
+        self._test_strtype('varchar', 'ï¿½')
 
     #
     # unicode
@@ -272,7 +272,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_unicode_%s' % len(value)] = _maketest(value)
 
     def test_unicode_upperlatin(self):
-        self._test_strtype('varchar', 'á')
+        self._test_strtype('varchar', 'ï¿½')
 
     #
     # binary
@@ -309,7 +309,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_image_%s' % len(value)] = _maketest(value)
 
     def test_image_upperlatin(self):
-        self._test_strliketype('image', buffer('á'))
+        self._test_strliketype('image', buffer('ï¿½'))
 
     #
     # text
@@ -330,7 +330,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strliketype('text', 'á')
+        self._test_strliketype('text', 'ï¿½')
 
     #
     # bit
@@ -1250,6 +1250,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -1258,4 +1260,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -254,7 +254,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', '�')
+        self._test_strtype('varchar', 'á')
 
     #
     # unicode
@@ -272,7 +272,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_unicode_%s' % len(value)] = _maketest(value)
 
     def test_unicode_upperlatin(self):
-        self._test_strtype('varchar', '�')
+        self._test_strtype('varchar', 'á')
 
     #
     # binary
@@ -309,7 +309,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_image_%s' % len(value)] = _maketest(value)
 
     def test_image_upperlatin(self):
-        self._test_strliketype('image', buffer('�'))
+        self._test_strliketype('image', buffer('á'))
 
     #
     # text
@@ -330,7 +330,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strliketype('text', '�')
+        self._test_strliketype('text', 'á')
 
     #
     # bit

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -197,7 +197,7 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', u'á', colsize=3)
+        self._test_strtype('varchar', u'ï¿½', colsize=3)
 
     def test_utf16(self):
         self.cursor.execute("create table t1(c1 varchar(100) character set utf16, c2 varchar(100))")
@@ -243,7 +243,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_blob_%s' % len(value)] = _maketest(value)
 
     def test_blob_upperlatin(self):
-        self._test_strtype('blob', bytes('á', 'utf-8'))
+        self._test_strtype('blob', bytes('ï¿½', 'utf-8'))
 
     #
     # text
@@ -261,7 +261,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('text', 'á')
+        self._test_strtype('text', 'ï¿½')
 
     #
     # unicode
@@ -777,6 +777,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -785,4 +787,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -197,7 +197,7 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', u'รก', colsize=3)
+        self._test_strtype('varchar', u'แ', colsize=3)
 
     def test_utf16(self):
         self.cursor.execute("create table t1(c1 varchar(100) character set utf16, c2 varchar(100))")
@@ -243,7 +243,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_blob_%s' % len(value)] = _maketest(value)
 
     def test_blob_upperlatin(self):
-        self._test_strtype('blob', bytes('รก', 'utf-8'))
+        self._test_strtype('blob', bytes('แ', 'utf-8'))
 
     #
     # text
@@ -261,7 +261,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('text', 'รก')
+        self._test_strtype('text', 'แ')
 
     #
     # unicode

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -197,7 +197,7 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', u'�', colsize=3)
+        self._test_strtype('varchar', u'á', colsize=3)
 
     def test_utf16(self):
         self.cursor.execute("create table t1(c1 varchar(100) character set utf16, c2 varchar(100))")
@@ -243,7 +243,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_blob_%s' % len(value)] = _maketest(value)
 
     def test_blob_upperlatin(self):
-        self._test_strtype('blob', bytes('�', 'utf-8'))
+        self._test_strtype('blob', bytes('á', 'utf-8'))
 
     #
     # text
@@ -261,7 +261,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('text', '�')
+        self._test_strtype('text', 'á')
 
     #
     # unicode

--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -19,6 +19,7 @@ You can also put the connection string into a tmp/setup.cfg file like so:
 Note: Be sure to use the "Unicode" (not the "ANSI") version of the PostgreSQL ODBC driver.
 """
 
+import sys
 import uuid
 import unittest
 from decimal import Decimal
@@ -702,7 +703,10 @@ def main():
         s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, m) for m in methods ])
 
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
-    testRunner.run(s)
+    result = testRunner.run(s)
+
+    return result
+
 
 if __name__ == '__main__':
 
@@ -711,4 +715,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/sqldwtests.py
+++ b/tests3/sqldwtests.py
@@ -1427,6 +1427,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -1435,4 +1437,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -193,7 +193,7 @@ class SqliteTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('varchar', '�')
+        self._test_strtype('varchar', 'á')
 
     #
     # blob

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -193,7 +193,7 @@ class SqliteTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('varchar', 'á')
+        self._test_strtype('varchar', 'ï¿½')
 
     #
     # blob
@@ -679,7 +679,7 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
-    sys.exit(result.errors and 1 or 0)
+    return result
 
 
 if __name__ == '__main__':
@@ -689,4 +689,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -193,7 +193,7 @@ class SqliteTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('varchar', 'รก')
+        self._test_strtype('varchar', 'แ')
 
     #
     # blob

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1808,6 +1808,8 @@ def main():
     testRunner = unittest.TextTestRunner(verbosity=options.verbose)
     result = testRunner.run(suite)
 
+    return result
+
 
 if __name__ == '__main__':
 
@@ -1816,4 +1818,4 @@ if __name__ == '__main__':
     add_to_path()
 
     import pyodbc
-    main()
+    sys.exit(0 if main().wasSuccessful() else 1)


### PR DESCRIPTION
When running the test scripts from the command line, it's useful to be able to tell programmatically if they succeeded or not.  To make this possible, this PR adds a `sys.exit()` call at the end of the `__main__` section of all the database test scripts.  The test scripts now return 0 if all the tests pass, 1 otherwise.

I've used the TestResult [wasSuccessful()](https://docs.python.org/3/library/unittest.html#unittest.TestResult.wasSuccessful) function to determine if the tests passed or not.  Happy to use an alternate function if preferred.