### PR TITLE
SyntaxError fix and other changes to some test scripts

### DIFF
--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -736,9 +736,10 @@ def main():
             parser.print_help()
             raise SystemExit()
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(MySqlTestCase, args.test, connection_string)
 

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -1,21 +1,21 @@
 #!/usr/bin/python
 # -*- coding: latin-1 -*-
 
-usage = """\
-usage: %prog [options] connection_string
-
+"""
 Unit tests for MySQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
 
-These tests use the pyodbc library from the build directory, not the version installed in your
-Python directories.  You must run `python setup.py build` before running these tests.
+These tests use the pyodbc library from the build directory, not the version
+installed in your Python directories.  You must run "python setup.py build"
+before running these tests.
 
 You can also put the connection string into a tmp/setup.cfg file like so:
 
   [mysqltests]
   connection-string=DRIVER=MySQL ODBC 8.0 ANSI Driver;charset=utf8mb4;SERVER=localhost;DATABASE=pyodbc;UID=root;PWD=rootpw
 
-Note: Use the "ANSI" (not the "Unicode") driver and include charset=utf8mb4 in the connection string so the high-Unicode tests won't fail.
+Note: Use the "ANSI" (not the "Unicode") driver and include charset=utf8mb4 in
+      the connection string so the high-Unicode tests won't fail.
 """
 
 import sys, os, re
@@ -717,18 +717,17 @@ class MySqlTestCase(unittest.TestCase):
 
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description=__doc__)
+    parser.add_argument("connection_string", nargs="?")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="Print debugging items")
+    parser.add_argument("-t", "--test", help="Run only the named test")
 
-    (options, args) = parser.parse_args()
-
-    if len(args) > 1:
-        parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
-
-    if not args:
+    args = parser.parse_args()
+    if args.connection_string:
+        connection_string = args.connection_string
+    else:
         filename = basename(sys.argv[0])
         assert filename.endswith('.py')
         connection_string = load_setup_connection_string(filename[:-3])
@@ -736,16 +735,14 @@ def main():
         if not connection_string:
             parser.print_help()
             raise SystemExit()
-    else:
-        connection_string = args[0]
 
     cnxn = pyodbc.connect(connection_string)
     print_library_info(cnxn)
     cnxn.close()
 
-    suite = load_tests(MySqlTestCase, options.test, connection_string)
+    suite = load_tests(MySqlTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
 

--- a/tests2/pgtests.py
+++ b/tests2/pgtests.py
@@ -1,14 +1,12 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-usage = """\
-usage: %prog [options] connection_string
-
+"""
 Unit tests for PostgreSQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
 
 These run using the version from the 'build' directory, not the version
-installed into the Python directories.  You must run python setup.py build
+installed into the Python directories.  You must run "python setup.py build"
 before running the tests.
 
 You can also put the connection string into a tmp/setup.cfg file like so:
@@ -528,47 +526,43 @@ class PGTestCase(unittest.TestCase):
 
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage="usage: %prog [options] connection_string")
-    parser.add_option("-v", "--verbose", action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
-    parser.add_option('-a', '--ansi', help='ANSI only', default=False, action='store_true')
-    parser.add_option('-u', '--unicode', help='Expect results in Unicode', default=False, action='store_true')
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description=__doc__)
+    parser.add_argument("connection_string", nargs="?")
+    parser.add_argument("-v", "--verbose", default=0, action="count", help="Increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="Print debugging items")
+    parser.add_argument("-t", "--test", help="Run only the named test")
+    parser.add_argument("-a", "--ansi", help="ANSI only", default=False, action="store_true")
+    parser.add_argument("-u", "--unicode", help="Expect results in Unicode", default=False, action="store_true")
 
-    (options, args) = parser.parse_args()
-
-    if len(args) > 1:
-        parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
-
-    if not args:
+    args = parser.parse_args()
+    if args.connection_string:
+        connection_string = args.connection_string
+    else:
         connection_string = load_setup_connection_string('pgtests')
-
         if not connection_string:
             parser.print_help()
             raise SystemExit()
-    else:
-        connection_string = args[0]
 
-    if options.verbose:
-        cnxn = pyodbc.connect(connection_string, ansi=options.ansi)
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string, ansi=args.ansi)
         print_library_info(cnxn)
         cnxn.close()
 
-    if options.test:
+    if args.test:
         # Run a single test
-        if not options.test.startswith('test_'):
-            options.test = 'test_%s' % (options.test)
+        if not args.test.startswith('test_'):
+            args.test = 'test_%s' % (args.test)
 
-        s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, options.unicode, options.test) ])
+        s = unittest.TestSuite([ PGTestCase(connection_string, args.ansi, args.unicode, args.test) ])
     else:
         # Run all tests in the class
 
         methods = [ m for m in dir(PGTestCase) if m.startswith('test_') ]
         methods.sort()
-        s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, options.unicode, m) for m in methods ])
+        s = unittest.TestSuite([ PGTestCase(connection_string, args.ansi, args.unicode, m) for m in methods ])
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(s)
 
 if __name__ == '__main__':

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1868,9 +1868,10 @@ def main():
             parser.print_help()
             raise SystemExit()
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, args.test, connection_string)
 

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: latin-1 -*-
 
+# Dummy line, do not remove. Otherwise, for Python 3.4/3.5/3.6, latin-1 coding + unix line endings = SyntaxError here.
 usage = """\
 usage: %prog [options] connection_string
 

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -766,9 +766,10 @@ def main():
             parser.print_help()
             raise SystemExit()
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(MySqlTestCase, args.test, connection_string)
 

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: latin-1 -*-
 
+# Dummy line. Otherwise, for Python 3.4/3.5/3.6, "latin-1" + unix line endings = SyntaxError here.
 """
 Unit tests for MySQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 # -*- coding: latin-1 -*-
 
-usage = """\
-usage: %prog [options] connection_string
-
+"""
 Unit tests for MySQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
 
-These tests use the pyodbc library from the build directory, not the version installed in your
-Python directories.  You must run `python setup.py build` before running these tests.
+These tests use the pyodbc library from the build directory, not the version
+installed in your Python directories.  You must run "python setup.py build"
+before running these tests.
 
 You can also put the connection string into a tmp/setup.cfg file like so:
 
   [mysqltests]
   connection-string=DRIVER=MySQL ODBC 8.0 ANSI Driver;charset=utf8mb4;SERVER=localhost;DATABASE=pyodbc;UID=root;PWD=rootpw
 
-Note: Use the "ANSI" (not the "Unicode") driver and include charset=utf8mb4 in the connection string so the high-Unicode tests won't fail.
+Note: Use the "ANSI" (not the "Unicode") driver and include charset=utf8mb4 in
+      the connection string so the high-Unicode tests won't fail.
 """
 
 import sys, os, re
@@ -746,18 +746,17 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(result, v)
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description=__doc__)
+    parser.add_argument("connection_string", nargs="?")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="Print debugging items")
+    parser.add_argument("-t", "--test", help="Run only the named test")
 
-    (options, args) = parser.parse_args()
-
-    if len(args) > 1:
-        parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
-
-    if not args:
+    args = parser.parse_args()
+    if args.connection_string:
+        connection_string = args.connection_string
+    else:
         filename = basename(sys.argv[0])
         assert filename.endswith('.py')
         connection_string = load_setup_connection_string(filename[:-3])
@@ -765,16 +764,14 @@ def main():
         if not connection_string:
             parser.print_help()
             raise SystemExit()
-    else:
-        connection_string = args[0]
 
     cnxn = pyodbc.connect(connection_string)
     print_library_info(cnxn)
     cnxn.close()
 
-    suite = load_tests(MySqlTestCase, options.test, connection_string)
+    suite = load_tests(MySqlTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
 

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: latin-1 -*-
 
-# Dummy line. Otherwise, for Python 3.4/3.5/3.6, "latin-1" + unix line endings = SyntaxError here.
+# Dummy line, do not remove. Otherwise, for Python 3.4/3.5/3.6, latin-1 coding + unix line endings = SyntaxError here.
 """
 Unit tests for MySQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.

--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-usage = """\
-usage: %prog [options] connection_string
-
+"""
 Unit tests for PostgreSQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
 
 These run using the version from the 'build' directory, not the version
-installed into the Python directories.  You must run python setup.py build
+installed into the Python directories.  You must run "python setup.py build"
 before running the tests.
 
 You can also put the connection string into a tmp/setup.cfg file like so:
@@ -662,46 +660,42 @@ class PGTestCase(unittest.TestCase):
         self.assertEqual(value, '123.45')
         
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage="usage: %prog [options] connection_string")
-    parser.add_option("-v", "--verbose", default=0, action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
-    parser.add_option('-a', '--ansi', help='ANSI only', default=False, action='store_true')
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description=__doc__)
+    parser.add_argument("connection_string", nargs="?")
+    parser.add_argument("-v", "--verbose", default=0, action="count", help="Increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="Print debugging items")
+    parser.add_argument("-t", "--test", help="Run only the named test")
+    parser.add_argument("-a", "--ansi", help="ANSI only", default=False, action="store_true")
 
-    (options, args) = parser.parse_args()
-
-    if len(args) > 1:
-        parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
-
-    if not args:
+    args = parser.parse_args()
+    if args.connection_string:
+        connection_string = args.connection_string
+    else:
         connection_string = load_setup_connection_string('pgtests')
-
         if not connection_string:
             parser.print_help()
             raise SystemExit()
-    else:
-        connection_string = args[0]
 
-    if options.verbose:
-        cnxn = pyodbc.connect(connection_string, ansi=options.ansi)
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string, ansi=args.ansi)
         print_library_info(cnxn)
         cnxn.close()
 
-    if options.test:
+    if args.test:
         # Run a single test
-        if not options.test.startswith('test_'):
-            options.test = 'test_%s' % (options.test)
+        if not args.test.startswith('test_'):
+            args.test = 'test_%s' % (args.test)
 
-        s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, options.test) ])
+        s = unittest.TestSuite([ PGTestCase(connection_string, args.ansi, args.test) ])
     else:
         # Run all tests in the class
 
         methods = [ m for m in dir(PGTestCase) if m.startswith('test_') ]
         methods.sort()
-        s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, m) for m in methods ])
+        s = unittest.TestSuite([ PGTestCase(connection_string, args.ansi, m) for m in methods ])
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     testRunner.run(s)
 
 if __name__ == '__main__':

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: latin-1 -*-
 
+# Dummy line, do not remove. Otherwise, for Python 3.4/3.5/3.6, latin-1 coding + unix line endings = SyntaxError here.
 usage = """\
 usage: %prog [options] connection_string
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1795,9 +1795,10 @@ def main():
             parser.print_help()
             raise SystemExit()
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, args.test, connection_string)
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1,16 +1,12 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-x = 1 # Getting an error if starting with usage for some reason.
-
-usage = """\
-usage: %prog [options] connection_string
-
+"""
 Unit tests for SQL Server.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
 
 These run using the version from the 'build' directory, not the version
-installed into the Python directories.  You must run python setup.py build
+installed into the Python directories.  You must run "python setup.py build"
 before running the tests.
 
 You can also put the connection string into a tmp/setup.cfg file like so:
@@ -24,7 +20,11 @@ is installed:
   2000: DRIVER={SQL Server}
   2005: DRIVER={SQL Server}
   2008: DRIVER={SQL Server Native Client 10.0}
-  
+  2012: DRIVER={SQL Server Native Client 11.0}
+  2014: DRIVER={ODBC Driver 11 for SQL Server}
+  2016: DRIVER={ODBC Driver 13 for SQL Server}
+  2017: DRIVER={ODBC Driver 17 for SQL Server}
+
 If using FreeTDS ODBC, be sure to use version 1.1.23 or newer.
 """
 
@@ -1779,33 +1779,29 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(success, True)
         
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description=__doc__)
+    parser.add_argument("connection_string", nargs="?")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="Print debugging items")
+    parser.add_argument("-t", "--test", help="Run only the named test")
 
-    (options, args) = parser.parse_args()
-
-    if len(args) > 1:
-        parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
-
-    if not args:
+    args = parser.parse_args()
+    if args.connection_string:
+        connection_string = args.connection_string
+    else:
         connection_string = load_setup_connection_string('sqlservertests')
-
         if not connection_string:
             parser.print_help()
             raise SystemExit()
-    else:
-        connection_string = args[0]
 
     cnxn = pyodbc.connect(connection_string)
     print_library_info(cnxn)
     cnxn.close()
 
-    suite = load_tests(SqlServerTestCase, options.test, connection_string)
+    suite = load_tests(SqlServerTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
 


### PR DESCRIPTION
This PR is related to PR #697 (the AppVeyor change).  Contrary to what I indicated earlier, it's best if this PR could be merged first, because it fixes and tidies up some things in the unit tests scripts used by that PR.

Various test scripts have been updated with the following changes:

1. Fix the SyntaxError issue for Python 3 test scripts that are coded in "latin-1".  There is a bug in Python 3.4, 3.5, and 3.6 which generates a SyntaxError when reading the coding.  It seems to be related to [this](https://bugs.python.org/issue20731) Python issue.
2. Call `print_library_info()` only when the "verbose" flag is set.  This has already been done on some test scripts, and it helps to keep the test output clean.
3. Convert the "usage" string defined at the start of some scripts to the module's [docstring](https://www.askpython.com/python/python-docstring).  Then the module docstring can be referenced in the rest of the module as simply `__doc__`.  A cosmetic change, it's true, but I believe it makes the code more Pythonesque.
4. I also took the liberty of switching from the `OptionParser` class to the `ArgumentParser` class for extracting the command line arguments.  The module `optparse` has been [deprecated](https://docs.python.org/3.8/library/optparse.html) since Python 3.2 so it would seem worthwhile to upgrade the code.
5. Finally, some minor formatting of the usage instructions.

Happy to back out any of these changes if necessary.