### PR TITLE
Fix SyntaxError error for non-utf8 coded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,55 @@
+# This file is based largely on the GitHub .gitignore template for Python:
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
 setup.cfg
+
+# C extensions
+*.so
+*.dll
+
+# Distribution / packaging
+build/
+dist/
+lib/
+lib64/
 MANIFEST
-build
-dist
-*.pdb
-*.pyc
-*.pyo
-tmp
-TAGS
-pyodbc.egg-info
-pyodbc.conf
+/PKG-INFO
+sdist/
+wheelhouse/
+*.egg-info/
+*.egg
+
+# Unit test / coverage reports
+.tox/
+.coverage
+
+# Virtual Environments
 /venv*
+/.env/
+/.venv
+
+# JetBrains
+.idea/
+
+# Visual Studio
+.vscode/
+.vs/
+*.sln
+*.vcxproj*
+x64/
+x86/
+*.pdb
+
+# Executables
+*.exe
+
+# Other
+pyodbc.conf
+tmp
+tags
 
 # The Access unit tests copy empty.accdb and empty.mdb to these names and use them.
 test.accdb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,123 @@
+# This AppVeyor CI configuration file:
+#   - builds pyodbc with multiple versions of Python
+#   - tests the generated pyodbc module against various databases and drivers
+#   - creates "wheel" files for distribution, and stores them as appveyor
+#     artifacts which can be downloaded from the AppVeyor UI
+#
+# Various aspects of this file's behavior can be controlled by setting environment
+# variables in the AppVeyor UI.  You will need an AppVeyor account for this (see
+# the Settings tab -> Environment -> Environment variables).  Here are
+# the relevant variables and their possible string values.  Note, "*" indicates the
+# defaults:
+#   - APVYR_RUN_TESTS - run the unit tests, overall control (true*/false)
+#   - APVYR_RUN_MSSQL_TESTS - run the MS SQL Server unit tests (true*/false)
+#   - APVYR_RUN_POSTGRES_TESTS - run the PostgreSQL unit tests (true*/false)
+#   - APVYR_RUN_MYSQL_TESTS - run the MySQL unit tests (true*/false)
+#   - APVYR_GENERATE_WHEELS - generate distributable wheel files (true/false*)
+#   - APVYR_VERBOSE - output more information to the logs (true/false*)
+#
+# For more information about appveyor.yml files, see: https://www.appveyor.com/docs/appveyor-yml/
 
-# https://packaging.python.org/appveyor/
 
-# This can't build 3.3 or 3.4 versions without a special build.cmd script,
-# defined in the article above. I don't feel like messing with it and am just
-# using this for build testing right now, so I'm not going to test every
-# version.
+# the AppVeyor cache is used to carry files between jobs, so make sure the jobs are serialized
+max_jobs: 1
+
+# the default AppVeyor image for the jobs, but the images are also set in the matrix
+image: Visual Studio 2019
 
 environment:
 
-  matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Python27"
-      PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python36"
-      PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Python36"
-      PYTHON_ARCH: "64"
+  global:
+    # the following variables can be overridden as necessary through the AppVeyor UI
+    APVYR_RUN_TESTS: "true"
+    APVYR_RUN_MSSQL_TESTS: "true"
+    APVYR_RUN_POSTGRES_TESTS: "true"
+    APVYR_RUN_MYSQL_TESTS: "true"
+    APVYR_GENERATE_WHEELS: "false"
+    APVYR_VERBOSE: "false"
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # http://stackoverflow.com/a/13751649/163740
+    # http://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros#microsoft-specific-predefined-macros
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\compile.cmd"
+    # database-related variables, which must match the "services:" section below
+    # ref: https://www.appveyor.com/docs/services-databases/
+    MSSQL_INSTANCE: "(local)\\SQL2017"
+    POSTGRES_PATH: "C:\\Program Files\\PostgreSQL\\11"
+    MYSQL_PATH: "C:\\Program Files\\MySQL\\MySQL Server 5.7"
 
-build: off
+  matrix:
+
+    # all the Python versions to be tested, both 32-bit and 64-bit
+    # ref: https://www.appveyor.com/docs/windows-images-software/#python
+
+    # Python 2.7 must be built with Visual Studio 9.0, which is available only
+    # on AppVeyor Windows images Visual Studio 2013 and Visual Studio 2015
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      PYTHON_HOME: "C:\\Python27"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      PYTHON_HOME: "C:\\Python27-x64"
+
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   PYTHON_HOME: "C:\\Python33"
+
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   PYTHON_HOME: "C:\\Python33-x64"
+
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   PYTHON_HOME: "C:\\Python34"
+
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   PYTHON_HOME: "C:\\Python34-x64"
+
+    # Python 3.5+ need at least the Visual Studio 2015 image
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python35"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python35-x64"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python36"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python36-x64"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python37"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python37-x64"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python38"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python38-x64"
+
+cache:
+  - apvyr_cache -> appveyor\install.ps1
+
+install:
+  - ps: .\appveyor\install.ps1
+
+# ref: https://www.appveyor.com/docs/services-databases/
+services:
+  - mssql2017
+  - postgresql11
+  - mysql
+
+build_script:
+  - call .\appveyor\build_script.cmd
 
 test_script:
-  - "%PYTHON%\\python.exe setup.py build"
+  - call .\appveyor\test_script.cmd
+
+after_test:
+  - call .\appveyor\after_test.cmd
+
+artifacts:
+  - path: 'dist\*.whl'

--- a/appveyor/after_test.cmd
+++ b/appveyor/after_test.cmd
@@ -1,0 +1,13 @@
+IF "%APVYR_GENERATE_WHEELS%" == "true" (
+  ECHO *** pip install the "wheel" module
+  "%PYTHON_HOME%\python" -m pip install wheel --quiet --no-warn-script-location
+  ECHO.
+  ECHO *** Generate the wheel file
+  %WITH_COMPILER% "%PYTHON_HOME%\python" setup.py bdist_wheel
+  ECHO.
+  ECHO *** \dist directory listing:
+  DIR /B dist
+) ELSE (
+  ECHO *** Skipping generation of the wheel file
+  ECHO.
+)

--- a/appveyor/build_script.cmd
+++ b/appveyor/build_script.cmd
@@ -1,0 +1,55 @@
+ECHO *** Environment variables:
+ECHO APPVEYOR_BUILD_FOLDER      : %APPVEYOR_BUILD_FOLDER%
+ECHO APPVEYOR_BUILD_WORKER_IMAGE: %APPVEYOR_BUILD_WORKER_IMAGE%
+ECHO APPVEYOR_JOB_NUMBER: %APPVEYOR_JOB_NUMBER%
+ECHO APPVEYOR_JOB_ID    : %APPVEYOR_JOB_ID%
+ECHO APPVEYOR_JOB_NAME  : %APPVEYOR_JOB_NAME%
+ECHO APVYR_RUN_TESTS         : %APVYR_RUN_TESTS%
+ECHO APVYR_RUN_MSSQL_TESTS   : %APVYR_RUN_MSSQL_TESTS%
+ECHO APVYR_RUN_POSTGRES_TESTS: %APVYR_RUN_POSTGRES_TESTS%
+ECHO APVYR_RUN_MYSQL_TESTS   : %APVYR_RUN_MYSQL_TESTS%
+ECHO APVYR_GENERATE_WHEELS   : %APVYR_GENERATE_WHEELS%
+ECHO APVYR_VERBOSE           : %APVYR_VERBOSE%
+ECHO PYTHON_HOME   : %PYTHON_HOME%
+ECHO MSSQL_INSTANCE: %MSSQL_INSTANCE%
+ECHO POSTGRES_PATH : %POSTGRES_PATH%
+ECHO MYSQL_PATH    : %MYSQL_PATH%
+
+ECHO.
+ECHO *** Get build info and compiler for the current Python installation:
+"%PYTHON_HOME%\python" -c "import platform; print(platform.python_build(), platform.python_compiler())"
+
+ECHO.
+ECHO *** Update pip and setuptools...
+"%PYTHON_HOME%\python" -m pip install --upgrade pip setuptools --quiet --no-warn-script-location
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: pip/setuptools update failed
+  EXIT 1
+)
+"%PYTHON_HOME%\python" -m pip freeze --all
+
+ECHO.
+ECHO *** Building the pyodbc module...
+%WITH_COMPILER% "%PYTHON_HOME%\python" setup.py build
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: pyodbc build failed
+  EXIT 1
+)
+
+ECHO.
+ECHO *** Installing pyodbc...
+"%PYTHON_HOME%\python" setup.py install
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: pyodbc install failed
+  EXIT 1
+)
+
+ECHO.
+ECHO *** pip freeze...
+"%PYTHON_HOME%\python" -m pip freeze --all
+
+ECHO.
+ECHO *** Get version of the built pyodbc module:
+"%PYTHON_HOME%\python" -c "import pyodbc; print(pyodbc.version)"
+
+ECHO.

--- a/appveyor/compile.cmd
+++ b/appveyor/compile.cmd
@@ -1,0 +1,84 @@
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: The repeated CALL commands at the end of this file look redundant, but
+:: if you move them outside the IF clauses, they do not run properly in
+:: the SET_SDK_64==Y case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=C:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions of the current Python interpreter, and bitness
+FOR /F "tokens=* USEBACKQ" %%F IN (`%PYTHON_HOME%\python -c "import sys; sys.stdout.write(str(sys.version_info.major))"`) DO (
+SET PYTHON_MAJOR_VERSION=%%F
+)
+FOR /F "tokens=* USEBACKQ" %%F IN (`%PYTHON_HOME%\python -c "import sys; sys.stdout.write(str(sys.version_info.minor))"`) DO (
+SET PYTHON_MINOR_VERSION=%%F
+)
+FOR /F "tokens=* USEBACKQ" %%F IN (`%PYTHON_HOME%\python -c "import sys; sys.stdout.write('64' if sys.maxsize > 2**32 else '32')"`) DO (
+SET PYTHON_ARCH=%%F
+)
+ECHO Inferred Python version (major, minor, arch): %PYTHON_MAJOR_VERSION% %PYTHON_MINOR_VERSION% %PYTHON_ARCH%
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %PYTHON_MAJOR_VERSION% EQU 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %PYTHON_MAJOR_VERSION% EQU 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %PYTHON_MINOR_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%PYTHON_MAJOR_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% EQU 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %PYTHON_MAJOR_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        CALL %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        CALL %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    CALL %COMMAND_TO_RUN% || EXIT 1
+)

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,234 @@
+# check that all the required ODBC drivers are available, and install any that are missing
+
+Function DownloadFileFromUrl ($url, $file_path) {
+    # try multiple times to download the file
+    $success = $false
+    $attempt_number = 1
+    $max_attempts = 5
+    while ($true) {
+        try {
+            Start-FileDownload -Url $url -FileName $file_path
+            $success = $true
+        } catch {
+            Write-Error $_
+            Write-Output "WARNING: download attempt number $attempt_number of $max_attempts failed"
+        }
+        if ($success) {return}
+        if ($attempt_number -ge $max_attempts) {break}
+        Start-Sleep -Seconds 10
+        $attempt_number += 1
+    }
+    # delete the file, just in case, to indicate failure
+    if (Test-Path $file_path) {
+        Remove-Item $file_path
+    }
+}
+
+Function CheckAndInstallMsiFromUrl ($driver_name, $driver_bitness, $driver_url, $msifile_path, $msiexec_paras) {
+    Write-Output ""
+
+    # check whether the driver is already installed
+    $d = Get-OdbcDriver -Name $driver_name -Platform $driver_bitness -ErrorAction:SilentlyContinue
+    if ($?) {
+        Write-Output "*** Driver ""$driver_name"" ($driver_bitness) already installed: $($d.Attribute.Driver)"
+        return
+    } else {
+        Write-Output "*** Driver ""$driver_name"" ($driver_bitness) not found"
+    }
+
+    # get the driver's msi file, check the AppVeyor cache first
+    if (Test-Path $msifile_path) {
+        Write-Output "Driver's msi file found in the cache"
+    } else {
+        DownloadFileFromUrl -url $driver_url -file_path $msifile_path
+        If (-Not (Test-Path $msifile_path)) {
+            Write-Output "ERROR: Could not download the msi file from ""$driver_url"""
+            return
+        }
+    }
+
+    # install the driver's msi file
+    # Note, there is an alternate method of calling msiexec.exe using cmd:
+    #   cmd /c start /wait msiexec.exe /i "$msifile_path" /quiet /qn /norestart
+    #   if (!$?) {...}
+    Write-Output "Installing the driver..."
+    $msi_args = @("/quiet", "/passive", "/qn", "/norestart", "/i", ('"{0}"' -f $msifile_path))
+    if ($msiexec_paras) {
+        $msi_args += $msiexec_paras
+    }
+    $result = Start-Process "msiexec.exe" -ArgumentList $msi_args -Wait -PassThru
+    if ($result.ExitCode -ne 0) {
+        Write-Output "ERROR: Driver installation failed"
+        Write-Output $result
+        return
+
+    }
+    Write-Output "...driver installed successfully"
+}
+
+Function CheckAndInstallZippedMsiFromUrl ($driver_name, $driver_bitness, $driver_url, $zipfile_path, $zip_internal_msi_file, $msifile_path) {
+    Write-Output ""
+    # check whether the driver is already installed
+    if ($d = Get-OdbcDriver -Name $driver_name -Platform $driver_bitness -ErrorAction:SilentlyContinue) {
+        Write-Output "*** Driver ""$driver_name"" ($driver_bitness) already installed: $($d.Attribute.Driver)"
+        return
+    } else {
+        Write-Output "*** Driver ""$driver_name"" ($driver_bitness) not found"
+    }
+    if (Test-Path $msifile_path) {
+        Write-Output "Driver's msi file found in the cache"
+    } else {
+        DownloadFileFromUrl -url $driver_url -file_path $zipfile_path
+        If (-Not (Test-Path $zipfile_path)) {
+            Write-Output "ERROR: Could not download the zip file from $driver_url"
+            return
+        }
+        Write-Output "Unzipping..."
+        Expand-Archive -Path $zipfile_path -DestinationPath $temp_dir
+        Copy-Item -Path "$temp_dir\$zip_internal_msi_file" -Destination $msifile_path -Force
+    }
+    Write-Output "Installing the driver..."
+    $msi_args = @("/i", ('"{0}"' -f $msifile_path), "/quiet", "/qn", "/norestart")
+    $result = Start-Process "msiexec.exe" -ArgumentList $msi_args -Wait -PassThru
+    if ($result.ExitCode -ne 0) {
+        Write-Output "ERROR: Driver installation failed"
+        Write-Output $result
+        return
+    }
+    Write-Output "...driver installed successfully"
+}
+
+
+# get Python version and bitness
+$python_major_version = cmd /c "${env:PYTHON_HOME}\python" -c "import sys; sys.stdout.write(str(sys.version_info.major))"
+$python_minor_version = cmd /c "${env:PYTHON_HOME}\python" -c "import sys; sys.stdout.write(str(sys.version_info.minor))"
+$python_arch = cmd /c "${env:PYTHON_HOME}\python" -c "import sys; sys.stdout.write('64' if sys.maxsize > 2**32 else '32')"
+
+
+# directories used exclusively by AppVeyor
+$cache_dir = "$env:APPVEYOR_BUILD_FOLDER\apvyr_cache"
+If (Test-Path $cache_dir) {
+    Write-Output "*** Contents of the cache directory: $cache_dir"
+    Get-ChildItem $cache_dir
+} else {
+    Write-Output "*** Creating directory ""$cache_dir""..."
+    New-Item -ItemType Directory -Path $cache_dir | out-null
+}
+$temp_dir = "$env:APPVEYOR_BUILD_FOLDER\apvyr_tmp"
+If (-Not (Test-Path $temp_dir)) {
+    Write-Output "*** Creating directory ""$temp_dir""..."
+    New-Item -ItemType Directory -Path $temp_dir | out-null
+}
+
+
+# output the already available ODBC drivers before installation
+If (${env:APVYR_VERBOSE} -eq "true") {
+    Write-Output ""
+    Write-Output "*** Installed ODBC drivers:"
+    Get-OdbcDriver
+}
+
+
+# Microsoft SQL Server
+# AppVeyor build servers are always 64-bit and therefore only the 64-bit
+# SQL Server ODBC driver msi files can be installed on them.  However,
+# the 64-bit msi files include both 32-bit and 64-bit drivers anyway.
+
+# The "SQL Server Native Client 10.0" and "SQL Server Native Client 11.0" driver
+# downloads do not appear to be available, hence cannot be installed.
+
+CheckAndInstallMsiFromUrl `
+    -driver_name "ODBC Driver 11 for SQL Server" `
+    -driver_bitness "64-bit" `
+    -driver_url "https://download.microsoft.com/download/5/7/2/57249A3A-19D6-4901-ACCE-80924ABEB267/ENU/x64/msodbcsql.msi" `
+    -msifile_path "$cache_dir\msodbcsql_11.0.0.0_x64.msi" `
+    -msiexec_paras @("IACCEPTMSODBCSQLLICENSETERMS=YES", "ADDLOCAL=ALL");
+
+# with the 13.0 driver, some tests fail for Python 2.7 so using version 13.1
+# 13.0: https://download.microsoft.com/download/1/E/7/1E7B1181-3974-4B29-9A47-CC857B271AA2/English/X64/msodbcsql.msi
+# 13.1: https://download.microsoft.com/download/D/5/E/D5EEF288-A277-45C8-855B-8E2CB7E25B96/x64/msodbcsql.msi
+CheckAndInstallMsiFromUrl `
+    -driver_name "ODBC Driver 13 for SQL Server" `
+    -driver_bitness "64-bit" `
+    -driver_url "https://download.microsoft.com/download/D/5/E/D5EEF288-A277-45C8-855B-8E2CB7E25B96/x64/msodbcsql.msi" `
+    -msifile_path "$cache_dir\msodbcsql_13.1.0.0_x64.msi" `
+    -msiexec_paras @("IACCEPTMSODBCSQLLICENSETERMS=YES", "ADDLOCAL=ALL");
+
+CheckAndInstallMsiFromUrl `
+    -driver_name "ODBC Driver 17 for SQL Server" `
+    -driver_bitness "64-bit" `
+    -driver_url "https://download.microsoft.com/download/E/6/B/E6BFDC7A-5BCD-4C51-9912-635646DA801E/en-US/17.5.2.1/x64/msodbcsql.msi" `
+    -msifile_path "$cache_dir\msodbcsql_17.5.1.1_x64.msi" `
+    -msiexec_paras @("IACCEPTMSODBCSQLLICENSETERMS=YES", "ADDLOCAL=ALL");
+
+# some drivers must be installed in alignment with Python's bitness
+if ($python_arch -eq "64") {
+
+    CheckAndInstallZippedMsiFromUrl `
+        -driver_name "PostgreSQL Unicode(x64)" `
+        -driver_bitness "64-bit" `
+        -driver_url "https://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x64.zip" `
+        -zipfile_path "$temp_dir\psqlodbc_11_01_0000-x64.zip" `
+        -zip_internal_msi_file "psqlodbc_x64.msi" `
+        -msifile_path "$cache_dir\psqlodbc_11_01_0000-x64.msi";
+
+    # MySQL 8.0 drivers apparently don't work on Python 2.7 ("system error 126").
+    # Note, installing MySQL 8.0 ODBC drivers causes the 5.3 drivers to be uninstalled.
+    if ($python_major_version -eq "2") {
+        CheckAndInstallMsiFromUrl `
+            -driver_name "MySQL ODBC 5.3 ANSI Driver" `
+            -driver_bitness "64-bit" `
+            -driver_url "https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.14-winx64.msi" `
+            -msifile_path "$cache_dir\mysql-connector-odbc-5.3.14-winx64.msi";
+    } else {
+        CheckAndInstallMsiFromUrl `
+            -driver_name "MySQL ODBC 8.0 ANSI Driver" `
+            -driver_bitness "64-bit" `
+            -driver_url "https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.19-winx64.msi" `
+            -msifile_path "$cache_dir\mysql-connector-odbc-8.0.19-winx64.msi";
+    }
+
+} elseif ($python_arch -eq "32") {
+
+    CheckAndInstallZippedMsiFromUrl `
+        -driver_name "PostgreSQL Unicode" `
+        -driver_bitness "32-bit" `
+        -driver_url "https://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x86.zip" `
+        -zipfile_path "$temp_dir\psqlodbc_11_01_0000-x86.zip" `
+        -zip_internal_msi_file "psqlodbc_x86.msi" `
+        -msifile_path "$cache_dir\psqlodbc_11_01_0000-x86.msi";
+
+    # MySQL 8.0 drivers apparently don't work on Python 2.7 ("system error 126") so install 5.3 instead.
+    # Note, installing MySQL 8.0 ODBC drivers causes the 5.3 drivers to be uninstalled.
+    if ($python_major_version -eq 2) {
+        CheckAndInstallMsiFromUrl `
+            -driver_name "MySQL ODBC 5.3 ANSI Driver" `
+            -driver_bitness "32-bit" `
+            -driver_url "https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.14-win32.msi" `
+            -msifile_path "$cache_dir\mysql-connector-odbc-5.3.14-win32.msi";
+    } else {
+            CheckAndInstallMsiFromUrl `
+            -driver_name "MySQL ODBC 8.0 ANSI Driver" `
+            -driver_bitness "32-bit" `
+            -driver_url "https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.19-win32.msi" `
+            -msifile_path "$cache_dir\mysql-connector-odbc-8.0.19-win32.msi";
+    }
+} else {
+    Write-Output "ERROR: Unexpected Python architecture:"
+    Write-Output $python_arch
+}
+
+
+# output the contents of the temporary AppVeyor directories and
+# the ODBC drivers now available after installation
+If (${env:APVYR_VERBOSE} -eq "true") {
+    Write-Output ""
+    Write-Output "*** Contents of the cache directory: $cache_dir"
+    Get-ChildItem $cache_dir
+    Write-Output ""
+    Write-Output "*** Contents of the temporary directory: $temp_dir"
+    Get-ChildItem $temp_dir
+    Write-Output ""
+    Write-Output "*** Installed ODBC drivers:"
+    Get-OdbcDriver
+}

--- a/appveyor/test_connect.py
+++ b/appveyor/test_connect.py
@@ -1,0 +1,4 @@
+import sys
+import pyodbc
+c = pyodbc.connect(sys.argv[1])
+c.close()

--- a/appveyor/test_script.cmd
+++ b/appveyor/test_script.cmd
@@ -1,0 +1,230 @@
+REM 0 = success, 1 = failure
+SET OVERALL_RESULT=0
+
+
+REM Output a list of the ODBC drivers available to pyodbc
+ECHO *** Available ODBC Drivers:
+"%PYTHON_HOME%\python" -c "import pyodbc; print('\n'.join(sorted(pyodbc.drivers())))"
+
+
+REM check if any testing should be done at all
+IF NOT "%APVYR_RUN_TESTS%" == "true" (
+  ECHO *** Skipping all the unit tests
+  GOTO :end
+)
+
+
+REM Extract the major version of the current Python interpreter, and bitness
+FOR /F "tokens=* USEBACKQ" %%F IN (`%PYTHON_HOME%\python -c "import sys; sys.stdout.write(str(sys.version_info.major))"`) DO (
+SET PYTHON_MAJOR_VERSION=%%F
+)
+FOR /F "tokens=* USEBACKQ" %%F IN (`%PYTHON_HOME%\python -c "import sys; sys.stdout.write('64' if sys.maxsize > 2**32 else '32')"`) DO (
+SET PYTHON_ARCH=%%F
+)
+IF %PYTHON_MAJOR_VERSION% EQU 2 (
+    SET TESTS_DIR=tests2
+) ELSE (
+    SET TESTS_DIR=tests3
+)
+
+
+:mssql
+ECHO.
+ECHO ############################################################
+ECHO # MS SQL Server
+ECHO ############################################################
+IF NOT "%APVYR_RUN_MSSQL_TESTS%" == "true" (
+  ECHO *** Skipping the MS SQL Server unit tests
+  GOTO :postgresql
+)
+ECHO *** Get MS SQL Server version:
+sqlcmd -S "%MSSQL_INSTANCE%" -U sa -P "Password12!" -Q "SELECT @@VERSION"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not connect to instance
+  GOTO :postgresql
+)
+ECHO *** Create test database
+sqlcmd -S "%MSSQL_INSTANCE%" -U sa -P "Password12!" -Q "CREATE DATABASE test_db"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not create the test database
+  GOTO :postgresql
+)
+
+:mssql1
+REM Native Client 10.0 is so old, it might not be available on the server
+SET DRIVER={SQL Server Native Client 10.0}
+SET CONN_STR=Driver=%DRIVER%;Server=%MSSQL_INSTANCE%;Database=test_db;UID=sa;PWD=Password12!;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  REM Don't fail the tests if the driver can't be found
+  ECHO *** INFO: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  GOTO :mssql2
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\sqlservertests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+:mssql2
+REM Native Client 11.0 is so old, it might not be available on the server
+SET DRIVER={SQL Server Native Client 11.0}
+SET CONN_STR=Driver=%DRIVER%;Server=%MSSQL_INSTANCE%;Database=test_db;UID=sa;PWD=Password12!;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  REM Don't fail the tests if the driver can't be found
+  ECHO *** INFO: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  GOTO :mssql3
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\sqlservertests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+:mssql3
+SET DRIVER={ODBC Driver 11 for SQL Server}
+SET CONN_STR=Driver=%DRIVER%;Server=%MSSQL_INSTANCE%;Database=test_db;UID=sa;PWD=Password12!;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  SET OVERALL_RESULT=1
+  GOTO :mssql4
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\sqlservertests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+:mssql4
+SET DRIVER={ODBC Driver 13 for SQL Server}
+SET CONN_STR=Driver=%DRIVER%;Server=%MSSQL_INSTANCE%;Database=test_db;UID=sa;PWD=Password12!;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  SET OVERALL_RESULT=1
+  GOTO :mssql5
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\sqlservertests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+:mssql5
+SET DRIVER={ODBC Driver 17 for SQL Server}
+SET CONN_STR=Driver=%DRIVER%;Server=%MSSQL_INSTANCE%;Database=test_db;UID=sa;PWD=Password12!;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  SET OVERALL_RESULT=1
+  GOTO :postgresql
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\sqlservertests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+
+:postgresql
+REM TODO: create a separate database for the tests?
+ECHO.
+ECHO ############################################################
+ECHO # PostgreSQL
+ECHO ############################################################
+IF NOT "%APVYR_RUN_POSTGRES_TESTS%" == "true" (
+  ECHO *** Skipping the PostgreSQL unit tests
+  GOTO :mysql
+)
+ECHO *** Get PostgreSQL version
+SET PGPASSWORD=Password12!
+"%POSTGRES_PATH%\bin\psql" -U postgres -d postgres -c "SELECT version()"
+
+IF %PYTHON_ARCH% EQU 32 (
+  SET DRIVER={PostgreSQL Unicode}
+) ELSE (
+  SET DRIVER={PostgreSQL Unicode^(x64^)}
+)
+SET CONN_STR=Driver=%DRIVER%;Server=localhost;Port=5432;Database=postgres;Uid=postgres;Pwd=Password12!;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  SET OVERALL_RESULT=1
+  GOTO :mysql
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\pgtests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+
+:mysql
+REM TODO: create a separate database for the tests?  (with the right collation)
+REM       https://dev.mysql.com/doc/refman/5.7/en/charset-charsets.html
+REM       e.g. CREATE DATABASE test_db CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ECHO.
+ECHO ############################################################
+ECHO # MySQL
+ECHO ############################################################
+IF NOT "%APVYR_RUN_MYSQL_TESTS%" == "true" (
+  ECHO *** Skipping the MySQL unit tests
+  GOTO :end
+)
+ECHO *** Get MySQL version
+"%MYSQL_PATH%\bin\mysql" -u root -pPassword12! -e "STATUS"
+
+:mysql1
+REM MySQL 8.0 drivers apparently don't work on Python 2.7 ("system error 126") so use 5.3 instead.
+IF %PYTHON_MAJOR_VERSION% EQU 2 (
+  SET DRIVER={MySQL ODBC 5.3 ANSI Driver}
+) ELSE (
+  SET DRIVER={MySQL ODBC 8.0 ANSI Driver}
+)
+SET CONN_STR=Driver=%DRIVER%;Charset=utf8mb4;Server=localhost;Port=3306;Database=mysql;Uid=root;Pwd=Password12!;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  SET OVERALL_RESULT=1
+  GOTO :end
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\mysqltests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+
+:end
+ECHO.
+EXIT /B %OVERALL_RESULT%

--- a/tests2/accesstests.py
+++ b/tests2/accesstests.py
@@ -650,9 +650,10 @@ def main():
     CNXNSTRING = 'DRIVER={%s};DBQ=%s;ExtendedAnsiSQL=1' % (driver, dest)
     print(CNXNSTRING)
 
-    cnxn = pyodbc.connect(CNXNSTRING)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(AccessTestCase, options.test)
 

--- a/tests2/exceltests.py
+++ b/tests2/exceltests.py
@@ -122,9 +122,10 @@ def main():
     assert os.path.exists(filename)
     CNXNSTRING = 'Driver={Microsoft Excel Driver (*.xls)};DBQ=%s;READONLY=FALSE' % filename
 
-    cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(ExcelTestCase, options.test)
 

--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -1252,9 +1252,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(InformixTestCase, options.test, connection_string)
 

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -739,9 +739,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(MySqlTestCase, options.test, connection_string)
 

--- a/tests2/sqldwtests.py
+++ b/tests2/sqldwtests.py
@@ -1476,9 +1476,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, options.test, connection_string)
 

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1887,9 +1887,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, options.test, connection_string)
 

--- a/tests3/accesstests.py
+++ b/tests3/accesstests.py
@@ -607,9 +607,10 @@ def main():
     CNXNSTRING = 'DRIVER={%s};DBQ=%s;ExtendedAnsiSQL=1' % (DRIVERS[args.type], dest)
     print(CNXNSTRING)
 
-    cnxn = pyodbc.connect(CNXNSTRING)
-    print_library_info(cnxn)
-    cnxn.close()
+    if args.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(AccessTestCase, args.test)
 

--- a/tests3/exceltests.py
+++ b/tests3/exceltests.py
@@ -122,9 +122,10 @@ def main():
     assert os.path.exists(filename)
     CNXNSTRING = 'Driver={Microsoft Excel Driver (*.xls)};DBQ=%s;READONLY=FALSE' % filename
 
-    cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(ExcelTestCase, options.test)
 

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: latin-1 -*-
 
 usage = """\
 usage: %prog [options] connection_string
@@ -254,7 +253,7 @@ class InformixTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', 'แ')
+        self._test_strtype('varchar', 'รก')
 
     #
     # unicode
@@ -272,7 +271,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_unicode_%s' % len(value)] = _maketest(value)
 
     def test_unicode_upperlatin(self):
-        self._test_strtype('varchar', 'แ')
+        self._test_strtype('varchar', 'รก')
 
     #
     # binary
@@ -309,7 +308,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_image_%s' % len(value)] = _maketest(value)
 
     def test_image_upperlatin(self):
-        self._test_strliketype('image', buffer('แ'))
+        self._test_strliketype('image', buffer('รก'))
 
     #
     # text
@@ -330,7 +329,7 @@ class InformixTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strliketype('text', 'แ')
+        self._test_strliketype('text', 'รก')
 
     #
     # bit
@@ -1241,9 +1240,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(InformixTestCase, options.test, connection_string)
 

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: latin-1 -*-
 
 usage = """\
 usage: %prog [options] connection_string
@@ -197,7 +196,7 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(v3, row.c3)
 
     def test_varchar_upperlatin(self):
-        self._test_strtype('varchar', u'แ', colsize=3)
+        self._test_strtype('varchar', u'รก', colsize=3)
 
     def test_utf16(self):
         self.cursor.execute("create table t1(c1 varchar(100) character set utf16, c2 varchar(100))")
@@ -243,7 +242,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_blob_%s' % len(value)] = _maketest(value)
 
     def test_blob_upperlatin(self):
-        self._test_strtype('blob', bytes('แ', 'utf-8'))
+        self._test_strtype('blob', bytes('รก', 'utf-8'))
 
     #
     # text
@@ -261,7 +260,7 @@ class MySqlTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('text', 'แ')
+        self._test_strtype('text', 'รก')
 
     #
     # unicode
@@ -770,9 +769,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(MySqlTestCase, options.test, connection_string)
 

--- a/tests3/sqldwtests.py
+++ b/tests3/sqldwtests.py
@@ -1418,9 +1418,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, options.test, connection_string)
 

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: latin-1 -*-
 
 usage = """\
 usage: %prog [options] connection_string
@@ -193,7 +192,7 @@ class SqliteTestCase(unittest.TestCase):
         locals()['test_text_%s' % len(value)] = _maketest(value)
 
     def test_text_upperlatin(self):
-        self._test_strtype('varchar', 'แ')
+        self._test_strtype('varchar', 'รก')
 
     #
     # blob


### PR DESCRIPTION
There is a bug in Python 3.4, 3.5, and 3.6 which generates a SyntaxError when the coding declaration in the header (e.g. `# -*- coding: latin-1 -*-`) is read by the Python interpreter.  The issue occurs when the files have unix (line-feed) line endings and the coding is not "utf-8".  It seems to be related to Python issues [20731](https://bugs.python.org/issue20731), [20844](https://bugs.python.org/issue20844), [27797](https://bugs.python.org/issue27797), and [32809](https://bugs.python.org/issue32809).  This PR provides a workaround to that issue. 