### PR TITLE
Call print_library_info() in the tests only when the verbose flag is set

### DIFF
--- a/tests2/accesstests.py
+++ b/tests2/accesstests.py
@@ -650,9 +650,10 @@ def main():
     CNXNSTRING = 'DRIVER={%s};DBQ=%s;ExtendedAnsiSQL=1' % (driver, dest)
     print(CNXNSTRING)
 
-    cnxn = pyodbc.connect(CNXNSTRING)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(AccessTestCase, options.test)
 

--- a/tests2/exceltests.py
+++ b/tests2/exceltests.py
@@ -122,9 +122,10 @@ def main():
     assert os.path.exists(filename)
     CNXNSTRING = 'Driver={Microsoft Excel Driver (*.xls)};DBQ=%s;READONLY=FALSE' % filename
 
-    cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(ExcelTestCase, options.test)
 

--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -1252,9 +1252,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(InformixTestCase, options.test, connection_string)
 

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -739,9 +739,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(MySqlTestCase, options.test, connection_string)
 

--- a/tests2/sqldwtests.py
+++ b/tests2/sqldwtests.py
@@ -1476,9 +1476,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, options.test, connection_string)
 

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1887,9 +1887,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, options.test, connection_string)
 

--- a/tests3/accesstests.py
+++ b/tests3/accesstests.py
@@ -607,9 +607,10 @@ def main():
     CNXNSTRING = 'DRIVER={%s};DBQ=%s;ExtendedAnsiSQL=1' % (DRIVERS[args.type], dest)
     print(CNXNSTRING)
 
-    cnxn = pyodbc.connect(CNXNSTRING)
-    print_library_info(cnxn)
-    cnxn.close()
+    if args.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(AccessTestCase, args.test)
 

--- a/tests3/exceltests.py
+++ b/tests3/exceltests.py
@@ -122,9 +122,10 @@ def main():
     assert os.path.exists(filename)
     CNXNSTRING = 'Driver={Microsoft Excel Driver (*.xls)};DBQ=%s;READONLY=FALSE' % filename
 
-    cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(ExcelTestCase, options.test)
 

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -1241,9 +1241,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(InformixTestCase, options.test, connection_string)
 

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -770,9 +770,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(MySqlTestCase, options.test, connection_string)
 

--- a/tests3/sqldwtests.py
+++ b/tests3/sqldwtests.py
@@ -1418,9 +1418,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, options.test, connection_string)
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1812,9 +1812,10 @@ def main():
     else:
         connection_string = args[0]
 
-    cnxn = pyodbc.connect(connection_string)
-    print_library_info(cnxn)
-    cnxn.close()
+    if options.verbose:
+        cnxn = pyodbc.connect(connection_string)
+        print_library_info(cnxn)
+        cnxn.close()
 
     suite = load_tests(SqlServerTestCase, options.test, connection_string)
 


### PR DESCRIPTION
The function `print_library_info()` is used in test scripts to output a whole bunch of detailed info about pyodbc and the driver it is using.  For example:
```
python:  2.7.17 (v2.7.17:c2f86d86e6, Oct 19 2019, 20:49:36) [MSC v.1500 32 bit (Intel)]
pyodbc:  4.0.31b17+commit937a61c C:\projects\pyodbc\build\lib.win32-2.7\pyodbc.pyd
odbc:    03.80.0000
driver:  msodbcsql17.dll 17.05.0001
         supports ODBC version 03.80
os:      Windows
unicode: Py_Unicode=2 SQLWCHAR=2
Max VARCHAR = 8000
Max WVARCHAR = 4000
Max BINARY = 8000
         2012ServerR2 6.3.9600 Multiprocessor Free
```
This is useful for debugging, but when running the unit tests under normal circumstances, it kinda clutters up the output.  This PR changes the relevant code to output this information only if the "verbose" flag is set.  Actually, this behavior has already been implemented on most of the unit test scripts, this PR simply makes the behavior consistent on all unit test scripts.