### PR TITLE
Add more entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 # Python
 __pycache__/
 *.py[cod]
-pyodbc.conf
 setup.cfg
 
 # C extensions
@@ -17,10 +16,11 @@ dist/
 MANIFEST
 lib/
 lib64/
+/PKG-INFO
 sdist/
+/wheelhouse/
 *.egg-info/
 *.egg
-MANIFEST
 
 # Unit test / coverage reports
 .tox/
@@ -47,6 +47,7 @@ x86/
 *.exe
 
 # Other
+pyodbc.conf
 tmp
 
 # The Access unit tests copy empty.accdb and empty.mdb to these names and use them.

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,53 @@
-setup.cfg
-MANIFEST
-build
-dist
-*.pdb
-*.pyc
-*.pyo
-tmp
-TAGS
-pyodbc.egg-info
+# This file is based largely on the GitHub .gitignore template for Python:
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
 pyodbc.conf
-/venv*
+setup.cfg
+
+# C extensions
+*.so
+*.dll
+
+# Distribution / packaging
+build/
+dist/
+MANIFEST
+lib/
+lib64/
+sdist/
+*.egg-info/
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+.tox/
+.coverage
+
+# Virtual Environments
+/venv
+.env
+.venv
+
+# JetBrains
+.idea/
+
+# Visual Studio
+.vscode/
+.vs/
+*.sln
+*.vcxproj*
+x64/
+x86/
+*.pdb
+
+# Executables
+*.exe
+
+# Other
+tmp
 
 # The Access unit tests copy empty.accdb and empty.mdb to these names and use them.
 test.accdb

--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,12 @@ setup.cfg
 # Distribution / packaging
 build/
 dist/
-MANIFEST
 lib/
 lib64/
+MANIFEST
 /PKG-INFO
 sdist/
-/wheelhouse/
+wheelhouse/
 *.egg-info/
 *.egg
 
@@ -27,9 +27,9 @@ sdist/
 .coverage
 
 # Virtual Environments
-/venv
-.env
-.venv
+venv/
+.env/
+.venv/
 
 # JetBrains
 .idea/


### PR DESCRIPTION
This PR just adds some more entries to the `.gitignore` file to make it align better with Python/C++ development.  In particular, it adds file extensions used by various IDEs like Visual Studio.