### PR TITLE
Fix DSN truncation in dataSources()

### DIFF
--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -617,7 +617,7 @@ static PyObject* mod_datasources(PyObject* self)
     if (!result)
         return 0;
 
-    SQLCHAR szDSN[SQL_MAX_DSN_LENGTH];
+    SQLCHAR szDSN[SQL_MAX_DSN_LENGTH + 1];
     SWORD cbDSN;
     SQLCHAR szDesc[200];
     SWORD cbDesc;

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -617,9 +617,9 @@ static PyObject* mod_datasources(PyObject* self)
     if (!result)
         return 0;
 
-    SQLCHAR szDSN[SQL_MAX_DSN_LENGTH + 1];
+    SQLCHAR szDSN[500]; // Using a buffer larger than SQL_MAX_DSN_LENGTH + 1 for systems that ignore it
     SWORD cbDSN;
-    SQLCHAR szDesc[200];
+    SQLCHAR szDesc[500];
     SWORD cbDesc;
 
     SQLUSMALLINT nDirection = SQL_FETCH_FIRST;


### PR DESCRIPTION
Updated buffer array declaration to accommodate extra space for null terminator and therefore allow DSN to utilize all available space of 32 characters without truncation.

Fixes #718