### PR TITLE
fixes #520 caused by null parameters

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -618,6 +618,8 @@ static bool GetNullInfo(Cursor* cur, Py_ssize_t index, ParamInfo& info)
 
     info.ValueType     = SQL_C_DEFAULT;
     info.ColumnSize    = 1;
+    info.ParameterValuePtr = 0;
+    info.BufferLength = 0;
     info.StrLen_or_Ind = SQL_NULL_DATA;
     return true;
 }
@@ -1474,8 +1476,11 @@ bool BindParameter(Cursor* cur, Py_ssize_t index, ParamInfo& info)
                 // Bind the TVP's columns --- all need to use DAE
                 PyObject *param = PySequence_GetItem(row, i);
                 GetParameterInfo(cur, i, param, info.nested[i], true);
-                info.nested[i].BufferLength = info.nested[i].StrLen_or_Ind;
-                info.nested[i].StrLen_or_Ind = SQL_DATA_AT_EXEC;
+                if (info.nested[i].StrLen_or_Ind != SQL_NULL_DATA)
+                {
+                    info.nested[i].BufferLength = info.nested[i].StrLen_or_Ind;
+                    info.nested[i].StrLen_or_Ind = SQL_DATA_AT_EXEC;
+                }
 
                 Py_BEGIN_ALLOW_THREADS
                 ret = SQLBindParameter(cur->hstmt, (SQLUSMALLINT)(i + 1), SQL_PARAM_INPUT,

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -617,8 +617,9 @@ static bool GetNullInfo(Cursor* cur, Py_ssize_t index, ParamInfo& info)
         return false;
 
     info.ValueType     = SQL_C_DEFAULT;
+    info.ParameterType = SQL_VARCHAR;
     info.ColumnSize    = 1;
-    info.ParameterValuePtr = 0;
+    info.ParameterValuePtr = NULL;
     info.BufferLength = 0;
     info.StrLen_or_Ind = SQL_NULL_DATA;
     return true;


### PR DESCRIPTION
Hi, I would like to first start by saying I've never read any ODBC documentation until the last couple of days, so bear with me as I will try my best to explain the solution and why it makes sense.

Issue #520 happens when you pass "None" on a field that is nullable for a TVP argument of a stored procedure. The error message ([HY090](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlbindparameter-function?view=sql-server-2017)) says that BufferLength is invalid because it was less than 0.

I initially started by specifying BufferLength = 0 on GetNullInfo in params.cpp, but that was not working. After some debugging I narrowed down the location where this assignment was being overriden (see patch below). My solution was to check if this was a SQL_NULL_DATA situation - if so we leave StrLen_or_Ind and BufferLength the same (I did have to set BufferLength to 0), which works as expected.

**Why BufferLength = 0**

This is where I spent a little more time to see if anywhere in the ODBC specification it says BufferLength should be 0 when we are handling a NULL field. I couldn't find anything that specific, but I did notice that ValueType was VARCHAR, and I saw this [on the documentation for SQLPutData](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetdescfield-function?view=sql-server-2017):

> * If ValuePtr is a pointer to a character string, then BufferLength is the length of the string or SQL_NTS.

I guess you could say that a null pointer's size is 0, though it doesn't make that much sense to me since it's NULL. This is as far as I could take it - I can't really justify whether the value of 0 is correct, or if I should have set some other parameter property (like ValueType or ParameterType) to something else and then BufferLength would be ignored or would work with negative values).

So I now rely on maintainers' wisdom to finish this work.  

Thank you!