### PR TITLE
Do not include .pyc artifacts in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+global-exclude *.py
 include src/*.h
 include src/*.cpp
 include tests2/*


### PR DESCRIPTION
Those files should not be shipped in the source tarball. The last release 4.0.30
had three of those files:

    wget -q -O - https://files.pythonhosted.org/packages/81/0d/bb08bb16c97765244791c73e49de9fd4c24bb3ef00313aed82e5640dee5d/pyodbc-4.0.30.tar.gz |tar tz |grep '.pyc$'
    pyodbc-4.0.30/tests2/testutils.pyc
    pyodbc-4.0.30/tests2/pgtests.pyc
    pyodbc-4.0.30/tests3/testutils.pyc