### PR TITLE
New cursor "messages" attribute to retrieve PRINT statements

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -300,6 +300,7 @@ enum free_results_flags
     KEEP_STATEMENT = 0x02,
     FREE_PREPARED  = 0x04,
     KEEP_PREPARED  = 0x08,
+    KEEP_MESSAGES  = 0x10,
 
     STATEMENT_MASK = 0x03,
     PREPARED_MASK  = 0x0C
@@ -365,6 +366,12 @@ static bool free_results(Cursor* self, int flags)
         self->map_name_to_index = 0;
     }
 
+    if ((flags & KEEP_MESSAGES) == 0)
+    {
+        Py_XDECREF(self->messages);
+        self->messages = PyList_New(0);
+    }
+
     self->rowcount = -1;
 
     return true;
@@ -401,11 +408,13 @@ static void closeimpl(Cursor* cur)
     Py_XDECREF(cur->description);
     Py_XDECREF(cur->map_name_to_index);
     Py_XDECREF(cur->cnxn);
+    Py_XDECREF(cur->messages);
 
     cur->pPreparedSQL = 0;
     cur->description = 0;
     cur->map_name_to_index = 0;
     cur->cnxn = 0;
+    cur->messages = 0;
 }
 
 static char close_doc[] =
@@ -555,6 +564,83 @@ static bool PrepareResults(Cursor* cur, int cCols)
 }
 
 
+static int GetDiagRecs(Cursor* cur)
+{
+    // Retrieves all diagnostic records from the cursor and assigns them to the "messages" attribute.
+
+    PyObject* msg_list;
+
+    SQLSMALLINT iRecNumber = 1;
+
+    ODBCCHAR    cSQLState[6];  // five-character SQLSTATE code (plus terminating NULL)
+    SQLINTEGER  iNativeError;
+    ODBCCHAR    cMessageText[10240];  // PRINT statements can be large, hopefully 10K bytes will be enough
+    SQLSMALLINT iTextLength;
+
+    SQLRETURN ret;
+    char sqlstate_ascii[6] = "";  //  ASCII version of the SQLState
+
+    msg_list = PyList_New(0);
+    if (!msg_list)
+        return 0;
+
+    for (;;)
+    {
+        cSQLState[0]    = 0;
+        iNativeError    = 0;
+        cMessageText[0] = 0;
+        iTextLength     = 0;
+
+        Py_BEGIN_ALLOW_THREADS
+        ret = SQLGetDiagRecW(
+            SQL_HANDLE_STMT, cur->hstmt, iRecNumber, (SQLWCHAR*)cSQLState, &iNativeError,
+            (SQLWCHAR*)cMessageText, (short)(_countof(cMessageText)-1), &iTextLength
+        );
+        Py_END_ALLOW_THREADS
+        if (!SQL_SUCCEEDED(ret))
+            break;
+
+        cSQLState[5] = 0;  // Not always NULL terminated (MS Access)
+        CopySqlState(cSQLState, sqlstate_ascii);
+        PyObject* msg_class = PyUnicode_FromFormat("[%s] (%ld)", sqlstate_ascii, (long)iNativeError);
+
+        // Default to UTF-16, which may not work if the driver/manager is using some other encoding
+        const char *unicode_enc = cur->cnxn ? cur->cnxn->metadata_enc.name : ENCSTR_UTF16NE;
+        PyObject* msg_value = PyUnicode_Decode(
+            (char*)cMessageText, iTextLength * sizeof(ODBCCHAR), unicode_enc, "strict"
+        );
+        if (!msg_value)
+        {
+            // If the char cannot be decoded, return something rather than nothing.
+            Py_XDECREF(msg_value);
+            msg_value = PyBytes_FromStringAndSize((char*)cMessageText, iTextLength * sizeof(ODBCCHAR));
+        }
+
+        PyObject* msg_tuple = PyTuple_New(2);
+
+        if (msg_class && msg_value && msg_tuple)
+        {
+            PyTuple_SetItem(msg_tuple, 0, msg_class);  // msg_tuple now owns the msg_class reference
+            PyTuple_SetItem(msg_tuple, 1, msg_value);  // msg_tuple now owns the msg_value reference
+
+            PyList_Append(msg_list, msg_tuple);
+            Py_XDECREF(msg_tuple);  // whether PyList_Append succeeds or not
+        }
+        else
+        {
+            Py_XDECREF(msg_class);
+            Py_XDECREF(msg_value);
+            Py_XDECREF(msg_tuple);
+        }
+
+        iRecNumber++;
+    }
+
+    Py_XDECREF(cur->messages);
+    cur->messages = msg_list;  // cur->messages now owns the msg_list reference
+}
+
+
 static PyObject* execute(Cursor* cur, PyObject* pSql, PyObject* params, bool skip_first)
 {
     // Internal function to execute SQL, called by .execute and .executemany.
@@ -658,6 +744,11 @@ static PyObject* execute(Cursor* cur, PyObject* pSql, PyObject* params, bool ski
         RaiseErrorFromHandle(cur->cnxn, "SQLExecDirectW", cur->cnxn->hdbc, cur->hstmt);
         FreeParameterData(cur);
         return 0;
+    }
+
+    if (ret == SQL_SUCCESS_WITH_INFO)
+    {
+        GetDiagRecs(cur);
     }
 
     while (ret == SQL_NEED_DATA)
@@ -1777,6 +1868,7 @@ static PyObject* Cursor_nextset(PyObject* self, PyObject* args)
         free_results(cur, FREE_STATEMENT | KEEP_PREPARED);
         Py_RETURN_FALSE;
     }
+
     if (!SQL_SUCCEEDED(ret))
     {
         TRACE("nextset: %d not SQL_SUCCEEDED\n", ret);
@@ -1809,6 +1901,17 @@ static PyObject* Cursor_nextset(PyObject* self, PyObject* args)
         Py_RETURN_FALSE;
     }
 
+    // Must retrieve DiagRecs immediately after SQLMoreResults
+    if (ret == SQL_SUCCESS_WITH_INFO)
+    {
+        GetDiagRecs(cur);
+    }
+    else
+    {
+        Py_XDECREF(cur->messages);
+        cur->messages = PyList_New(0);
+    }
+
     SQLSMALLINT cCols;
     Py_BEGIN_ALLOW_THREADS
     ret = SQLNumResultCols(cur->hstmt, &cCols);
@@ -1819,10 +1922,10 @@ static PyObject* Cursor_nextset(PyObject* self, PyObject* args)
         // submitted.  This is not documented, but I've seen it with multiple successful inserts.
 
         PyObject* pError = GetErrorFromHandle(cur->cnxn, "SQLNumResultCols", cur->cnxn->hdbc, cur->hstmt);
-        free_results(cur, FREE_STATEMENT | KEEP_PREPARED);
+        free_results(cur, FREE_STATEMENT | KEEP_PREPARED | KEEP_MESSAGES);
         return pError;
     }
-    free_results(cur, KEEP_STATEMENT | KEEP_PREPARED);
+    free_results(cur, KEEP_STATEMENT | KEEP_PREPARED | KEEP_MESSAGES);
 
     if (cCols != 0)
     {
@@ -2102,6 +2205,10 @@ static char fastexecmany_doc[] =
     "This read/write attribute specifies whether to use a faster executemany() which\n" \
     "uses parameter arrays. Not all drivers may work with this implementation.";
 
+static char messages_doc[] =
+    "This read-only attribute is a list of all the diagnostic messages in the\n" \
+    "current result set.";
+
 static PyMemberDef Cursor_members[] =
 {
     {"rowcount",    T_INT,       offsetof(Cursor, rowcount),        READONLY, rowcount_doc },
@@ -2109,6 +2216,7 @@ static PyMemberDef Cursor_members[] =
     {"arraysize",   T_INT,       offsetof(Cursor, arraysize),       0,        arraysize_doc },
     {"connection",  T_OBJECT_EX, offsetof(Cursor, cnxn),            READONLY, connection_doc },
     {"fast_executemany",T_BOOL,  offsetof(Cursor, fastexecmany),    0,        fastexecmany_doc },
+    {"messages",    T_OBJECT_EX, offsetof(Cursor, messages),        READONLY, messages_doc },
     { 0 }
 };
 
@@ -2397,9 +2505,11 @@ Cursor_New(Connection* cnxn)
         cur->rowcount          = -1;
         cur->map_name_to_index = 0;
         cur->fastexecmany      = 0;
+        cur->messages          = Py_None;
 
         Py_INCREF(cnxn);
         Py_INCREF(cur->description);
+        Py_INCREF(cur->messages);
 
         SQLRETURN ret;
         Py_BEGIN_ALLOW_THREADS

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -150,6 +150,10 @@ struct Cursor
     // Since this is shared by Row objects, it cannot be reused.  New dictionaries are created for every execute.  This
     // will be zero whenever there are no results.
     PyObject* map_name_to_index;
+
+    // The messages attribute described in the DB API 2.0 specification.
+    // Contains a list of all non-data messages provided by the driver, retrieved using SQLGetDiagRec.
+    PyObject* messages;
 };
 
 void Cursor_init();

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -194,36 +194,6 @@ PyObject* RaiseErrorFromHandle(Connection *conn, const char* szFunction, HDBC hd
 }
 
 
-inline void CopySqlState(const ODBCCHAR* src, char* dest)
-{
-    // Copies a SQLSTATE read as SQLWCHAR into a character buffer.  We know that SQLSTATEs are
-    // composed of ASCII characters and we need one standard to compare when choosing
-    // exceptions.
-    //
-    // Strangely, even when the error messages are UTF-8, PostgreSQL and MySQL encode the
-    // sqlstate as UTF-16LE.  We'll simply copy all non-zero bytes, with some checks for
-    // running off the end of the buffers which will work for ASCII, UTF8, and UTF16 LE & BE.
-    // It would work for UTF32 if I increase the size of the ODBCCHAR buffer to handle it.
-    //
-    // (In the worst case, if a driver does something totally weird, we'll have an incomplete
-    // SQLSTATE.)
-    //
-
-    const char* pchSrc = (const char*)src;
-    const char* pchSrcMax = pchSrc + sizeof(ODBCCHAR) * 5;
-    char* pchDest = dest;         // Where we are copying into dest
-    char* pchDestMax = dest + 5;  // We know a SQLSTATE is 5 characters long
-
-    while (pchDest < pchDestMax && pchSrc < pchSrcMax)
-    {
-        if (*pchSrc)
-            *pchDest++ = *pchSrc;
-        pchSrc++;
-    }
-    *pchDest = 0;
-}
-
-
 PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc, HSTMT hstmt)
 {
     TRACE("In RaiseError(%s)!\n", szFunction);

--- a/src/errors.h
+++ b/src/errors.h
@@ -67,4 +67,33 @@ inline PyObject* RaiseErrorFromException(PyObject* pError)
     return 0;
 }
 
+inline void CopySqlState(const ODBCCHAR* src, char* dest)
+{
+    // Copies a SQLSTATE read as SQLWCHAR into a character buffer.  We know that SQLSTATEs are
+    // composed of ASCII characters and we need one standard to compare when choosing
+    // exceptions.
+    //
+    // Strangely, even when the error messages are UTF-8, PostgreSQL and MySQL encode the
+    // sqlstate as UTF-16LE.  We'll simply copy all non-zero bytes, with some checks for
+    // running off the end of the buffers which will work for ASCII, UTF8, and UTF16 LE & BE.
+    // It would work for UTF32 if I increase the size of the ODBCCHAR buffer to handle it.
+    //
+    // (In the worst case, if a driver does something totally weird, we'll have an incomplete
+    // SQLSTATE.)
+    //
+
+    const char* pchSrc = (const char*)src;
+    const char* pchSrcMax = pchSrc + sizeof(ODBCCHAR) * 5;
+    char* pchDest = dest;         // Where we are copying into dest
+    char* pchDestMax = dest + 5;  // We know a SQLSTATE is 5 characters long
+
+    while (pchDest < pchDestMax && pchSrc < pchSrcMax)
+    {
+        if (*pchSrc)
+            *pchDest++ = *pchSrc;
+        pchSrc++;
+    }
+    *pchDest = 0;
+}
+
 #endif // _ERRORS_H_

--- a/tests2/pgtests.py
+++ b/tests2/pgtests.py
@@ -526,6 +526,35 @@ class PGTestCase(unittest.TestCase):
 
         self.assertEqual(result, v)
 
+    def test_cursor_messages(self):
+        """
+        Test the Cursor.messages attribute.
+        """
+        # self.cursor is used in setUp, hence is not brand new at this point
+        brand_new_cursor = self.cnxn.cursor()
+        self.assertIsNone(brand_new_cursor.messages)
+
+        # using INFO message level because they are always sent to the client regardless of
+        # client_min_messages: https://www.postgresql.org/docs/11/runtime-config-client.html
+        self.cursor.execute("""
+            CREATE OR REPLACE PROCEDURE test_cursor_messages()
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RAISE INFO 'hello world' USING ERRCODE = '01000';
+            END;
+            $$;
+        """)
+        self.cursor.execute("CALL test_cursor_messages();")
+        self.assertTrue(type(self.cursor.messages) is list)
+        self.assertEqual(len(self.cursor.messages), 1)
+        self.assertTrue(type(self.cursor.messages[0]) is tuple)
+        self.assertEqual(len(self.cursor.messages[0]), 2)
+        self.assertTrue(type(self.cursor.messages[0][0]) is unicode)
+        self.assertTrue(type(self.cursor.messages[0][1]) is unicode)
+        self.assertEqual('[01000] (-1)', self.cursor.messages[0][0])
+        self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
+
 
 def main():
     from optparse import OptionParser

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1484,6 +1484,66 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(t[5], 2)       # scale
         self.assertEqual(t[6], True)    # nullable
 
+    def test_cursor_messages_with_print(self):
+        """
+        Ensure the Cursor.messages attribute is handled correctly with a simple PRINT statement.
+        """
+        # self.cursor is used in setUp, hence is not brand new at this point
+        brand_new_cursor = self.cnxn.cursor()
+        self.assertIsNone(brand_new_cursor.messages)
+
+        self.cursor.execute("PRINT 'hello world'")
+        self.assertTrue(type(self.cursor.messages) is list)
+        self.assertEqual(len(self.cursor.messages), 1)
+        self.assertTrue(type(self.cursor.messages[0]) is tuple)
+        self.assertEqual(len(self.cursor.messages[0]), 2)
+        self.assertTrue(type(self.cursor.messages[0][0]) is unicode)
+        self.assertTrue(type(self.cursor.messages[0][1]) is unicode)
+        self.assertEqual('[01000] (0)', self.cursor.messages[0][0])
+        self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
+
+    def test_cursor_messages_with_stored_proc(self):
+        """
+        Complex scenario to test the Cursor.messages attribute.
+        """
+        self.cursor.execute("""
+            CREATE OR ALTER PROCEDURE test_cursor_messages AS
+            BEGIN
+                SET NOCOUNT ON;
+                PRINT 'Message 1a';
+                PRINT 'Message 1b';
+                SELECT N'Field 1a' AS F UNION ALL SELECT N'Field 1b';
+                SELECT N'Field 2a' AS F UNION ALL SELECT N'Field 2b';
+                PRINT 'Message 2a';
+                PRINT 'Message 2b';
+            END
+        """)
+        # result set 1
+        self.cursor.execute("EXEC test_cursor_messages")
+        rows = [tuple(r) for r in self.cursor.fetchall()]  # convert pyodbc.Row objects for ease of use
+        self.assertEqual(len(rows), 2)
+        self.assertSequenceEqual(rows, [('Field 1a', ), ('Field 1b', )])
+        self.assertEqual(len(self.cursor.messages), 2)
+        self.assertTrue(self.cursor.messages[0][1].endswith('Message 1a'))
+        self.assertTrue(self.cursor.messages[1][1].endswith('Message 1b'))
+        # result set 2
+        self.assertTrue(self.cursor.nextset())
+        rows = [tuple(r) for r in self.cursor.fetchall()]  # convert pyodbc.Row objects for ease of use
+        self.assertEqual(len(rows), 2)
+        self.assertSequenceEqual(rows, [('Field 2a', ), ('Field 2b', )])
+        self.assertEqual(self.cursor.messages, [])
+        # result set 3
+        self.assertTrue(self.cursor.nextset())
+        with self.assertRaises(pyodbc.ProgrammingError):
+            self.cursor.fetchall()
+        self.assertEqual(len(self.cursor.messages), 2)
+        self.assertTrue(self.cursor.messages[0][1].endswith('Message 2a'))
+        self.assertTrue(self.cursor.messages[1][1].endswith('Message 2b'))
+        # result set 4 (which shouldn't exist)
+        self.assertFalse(self.cursor.nextset())
+        with self.assertRaises(pyodbc.ProgrammingError):
+            self.cursor.fetchall()
+        self.assertEqual(self.cursor.messages, [])
 
     def test_none_param(self):
         "Ensure None can be used for params other than the first"
@@ -1544,7 +1604,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(s varchar(800))")
         def test():
             self.cursor.execute("insert into t1 values (?)", value)
-        self.assertRaises(pyodbc.DataError, test)
+        # different versions of SQL Server generate different errors
+        self.assertRaises((pyodbc.DataError, pyodbc.ProgrammingError), test)
 
     def test_geometry_null_insert(self):
         def convert(value):

--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -623,7 +623,36 @@ class PGTestCase(unittest.TestCase):
         result = self.cursor.execute("select s from t1").fetchone()[0]
 
         self.assertEqual(result, v)
-        
+
+    def test_cursor_messages(self):
+        """
+        Test the Cursor.messages attribute.
+        """
+        # self.cursor is used in setUp, hence is not brand new at this point
+        brand_new_cursor = self.cnxn.cursor()
+        self.assertIsNone(brand_new_cursor.messages)
+
+        # using INFO message level because they are always sent to the client regardless of
+        # client_min_messages: https://www.postgresql.org/docs/11/runtime-config-client.html
+        self.cursor.execute("""
+            CREATE OR REPLACE PROCEDURE test_cursor_messages()
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RAISE INFO 'hello world' USING ERRCODE = '01000';
+            END;
+            $$;
+        """)
+        self.cursor.execute("CALL test_cursor_messages();")
+        self.assertTrue(type(self.cursor.messages) is list)
+        self.assertEqual(len(self.cursor.messages), 1)
+        self.assertTrue(type(self.cursor.messages[0]) is tuple)
+        self.assertEqual(len(self.cursor.messages[0]), 2)
+        self.assertTrue(type(self.cursor.messages[0][0]) is str)
+        self.assertTrue(type(self.cursor.messages[0][1]) is str)
+        self.assertEqual('[01000] (-1)', self.cursor.messages[0][0])
+        self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
+
     def test_output_conversion(self):
         # Note the use of SQL_WVARCHAR, not SQL_VARCHAR.
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1344,6 +1344,66 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(t[5], 2)       # scale
         self.assertEqual(t[6], True)    # nullable
 
+    def test_cursor_messages_with_print(self):
+        """
+        Ensure the Cursor.messages attribute is handled correctly with a simple PRINT statement.
+        """
+        # self.cursor is used in setUp, hence is not brand new at this point
+        brand_new_cursor = self.cnxn.cursor()
+        self.assertIsNone(brand_new_cursor.messages)
+
+        self.cursor.execute("PRINT 'hello world'")
+        self.assertTrue(type(self.cursor.messages) is list)
+        self.assertEqual(len(self.cursor.messages), 1)
+        self.assertTrue(type(self.cursor.messages[0]) is tuple)
+        self.assertEqual(len(self.cursor.messages[0]), 2)
+        self.assertTrue(type(self.cursor.messages[0][0]) is str)
+        self.assertTrue(type(self.cursor.messages[0][1]) is str)
+        self.assertEqual('[01000] (0)', self.cursor.messages[0][0])
+        self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
+
+    def test_cursor_messages_with_stored_proc(self):
+        """
+        Complex scenario to test the Cursor.messages attribute.
+        """
+        self.cursor.execute("""
+            CREATE OR ALTER PROCEDURE test_cursor_messages AS
+            BEGIN
+                SET NOCOUNT ON;
+                PRINT 'Message 1a';
+                PRINT 'Message 1b';
+                SELECT N'Field 1a' AS F UNION ALL SELECT N'Field 1b';
+                SELECT N'Field 2a' AS F UNION ALL SELECT N'Field 2b';
+                PRINT 'Message 2a';
+                PRINT 'Message 2b';
+            END
+        """)
+        # result set 1
+        self.cursor.execute("EXEC test_cursor_messages")
+        rows = [tuple(r) for r in self.cursor.fetchall()]  # convert pyodbc.Row objects for ease of use
+        self.assertEqual(len(rows), 2)
+        self.assertSequenceEqual(rows, [('Field 1a', ), ('Field 1b', )])
+        self.assertEqual(len(self.cursor.messages), 2)
+        self.assertTrue(self.cursor.messages[0][1].endswith('Message 1a'))
+        self.assertTrue(self.cursor.messages[1][1].endswith('Message 1b'))
+        # result set 2
+        self.assertTrue(self.cursor.nextset())
+        rows = [tuple(r) for r in self.cursor.fetchall()]  # convert pyodbc.Row objects for ease of use
+        self.assertEqual(len(rows), 2)
+        self.assertSequenceEqual(rows, [('Field 2a', ), ('Field 2b', )])
+        self.assertEqual(self.cursor.messages, [])
+        # result set 3
+        self.assertTrue(self.cursor.nextset())
+        with self.assertRaises(pyodbc.ProgrammingError):
+            self.cursor.fetchall()
+        self.assertEqual(len(self.cursor.messages), 2)
+        self.assertTrue(self.cursor.messages[0][1].endswith('Message 2a'))
+        self.assertTrue(self.cursor.messages[1][1].endswith('Message 2b'))
+        # result set 4 (which shouldn't exist)
+        self.assertFalse(self.cursor.nextset())
+        with self.assertRaises(pyodbc.ProgrammingError):
+            self.cursor.fetchall()
+        self.assertEqual(self.cursor.messages, [])
 
     def test_none_param(self):
         "Ensure None can be used for params other than the first"
@@ -1459,7 +1519,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(s varchar(800))")
         def test():
             self.cursor.execute("insert into t1 values (?)", value)
-        self.assertRaises(pyodbc.DataError, test)
+        # different versions of SQL Server generate different errors
+        self.assertRaises((pyodbc.DataError, pyodbc.ProgrammingError), test)
 
     def test_geometry_null_insert(self):
         def convert(value):


### PR DESCRIPTION
Here is my attempt to implement a mechanism for retrieving errors, warnings, and PRINT statements from the database in the manner [described](https://www.python.org/dev/peps/pep-0249/#cursor-messages) in PEP-249, i.e. through the use of a "messages" attribute on cursor objects.  This functionality is being tracked in issue #495 .

Currently, it is not possible for pyodbc clients to retrieve any errors, warnings, or other messages that have been generated by the database.  For example, `PRINT 'Start of Proc'` outputs a message, but pyodbc currently ignores it.  These messages are made available by the driver manager as "diagnostic records" through the [SQLGetDiagRec](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdiagrec-function) function.

PEP-249 [suggests](https://www.python.org/dev/peps/pep-0249/#cursor-messages) these messages should be made available as a list of tuples, where each tuple is made up of an "exception class" and an "exception message".  I'm not sure what that "exception class" is supposed to be, so for the moment I am simply including the SQLSTATE and the error number in the first element of the tuple, formatted in alignment with the current exception message format, and including the error message in the second element, e.g.:
```python
crsr.execute("PRINT 'hello world'")
print(crsr.messages)
```
would output:
```
[('[01000] (0)', '[Microsoft][ODBC Driver 17 for SQL Server][SQL Server]hello world')]
```

Each time `nextset()` is called, the messages are deleted and replaced with new messages from the result set (if any).  It should be noted, each result set can include both row data and messages.  It's also possible to have a result set that includes messages but does not have any row data.  (This isn't a change in behavior, it's always been possible to have a results set with no actual data records.)  In that scenario, clients can read any messages with `crsr.messages` but if they try to call `fetchall()`, an exception is generated.  This behavior is [per PEP-249](https://www.python.org/dev/peps/pep-0249/#fetchall).  Personally, I think it might have been easier if `fetchall()` just returned `None` if there weren't any records rather than raise an exception, but that's how PEP-249 is written.  On a brand new cursor object, the cursor message attribute starts out as `None`.  After calling `execute()` or `nextset()`, if no messages are available, an empty list is returned.

As part of this work, I exposed the method `CopySqlState()` by moving it from `errors.cpp` to `errors.h` so that it is available from `cursor.cpp`.

Memory management was checked using the [psutil](https://github.com/giampaolo/psutil) library.

A quick word on unit tests for the various databases.  SQL Server has a built-in [PRINT](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/print-transact-sql) statement, so that's relatively easy to test.  PostgreSQL doesn't support PRINT but has [RAISE INFO](https://www.postgresql.org/docs/11/plpgsql-errors-and-messages.html) instead.  For multiple RAISE INFO statements though, it appears only the last one is returned to the client.  As far as I can tell, MySQL doesn't have any way of returning commentary to the client.

Any and all thoughts welcome.