### PR TITLE
SQL Server 2019 change of data truncation error

### DIFF
--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1544,7 +1544,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(s varchar(800))")
         def test():
             self.cursor.execute("insert into t1 values (?)", value)
-        self.assertRaises(pyodbc.DataError, test)
+        # different versions of SQL Server generate different errors
+        self.assertRaises((pyodbc.DataError, pyodbc.ProgrammingError), test)
 
     def test_geometry_null_insert(self):
         def convert(value):

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1459,7 +1459,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(s varchar(800))")
         def test():
             self.cursor.execute("insert into t1 values (?)", value)
-        self.assertRaises(pyodbc.DataError, test)
+        # different versions of SQL Server generate different errors
+        self.assertRaises((pyodbc.DataError, pyodbc.ProgrammingError), test)
 
     def test_geometry_null_insert(self):
         def convert(value):


### PR DESCRIPTION
In SQL Server 2019, the error message generated for data truncation errors has [changed](https://support.microsoft.com/en-us/help/4468101/optional-replacement-for-string-or-binary-data-would-be-truncated) (for the better!).  In SS2019 this raises a `pyodbc.ProgrammingError` exception rather than a `pyodbc.DataError` exception, which breaks some unit tests when run on SS2019.  This PR changes the relevant unit tests to check for `pyodbc.DataError` or `pyodbc.ProgrammingError`, so that the tests pass for both SQL Server 2019 and older SQL Server instances.