### PR TITLE
Bind TVP columns even when the table is empty

### DIFF
--- a/src/cursor.h
+++ b/src/cursor.h
@@ -68,6 +68,9 @@ struct ParamInfo
     struct ParamInfo *nested;
     SQLLEN curTvpRow;
 
+    // For TVPs, the name of the table type.
+    SQLWCHAR* type_name;
+
     // Optional data.  If used, ParameterValuePtr will point into this.
     union
     {

--- a/src/pyodbc.h
+++ b/src/pyodbc.h
@@ -82,6 +82,14 @@ typedef int Py_ssize_t;
 #define SQL_CA_SS_TYPE_NAME 1227
 #endif
 
+#ifndef SQL_SOPT_SS_NAME_SCOPE
+#define SQL_SOPT_SS_NAME_SCOPE 1237
+#endif
+
+#ifndef SQL_SS_NAME_SCOPE_TABLE_TYPE
+#define SQL_SS_NAME_SCOPE_TABLE_TYPE 1
+#endif
+
 inline bool IsSet(DWORD grf, DWORD flags)
 {
     return (grf & flags) == flags;

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1863,6 +1863,13 @@ class SqlServerTestCase(unittest.TestCase):
                         print("Mismatch at row " + str(r+1) + ", column " + str(c+1) + "; expected:", param_array[r][c] , " received:", result_array[r][c])
                         success = False
 
+        try:
+            result_array = self.cursor.execute("exec SelectTVP ?", [[]])
+        except Exception as ex:
+            print("Failed to execute SelectTVP")
+            print("Exception: [" + type(ex).__name__ + "]" , ex.args)
+            success = False
+
         self.assertEqual(success, True)
 
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1789,6 +1789,13 @@ class SqlServerTestCase(unittest.TestCase):
                         print("Mismatch at row " + str(r+1) + ", column " + str(c+1) + "; expected:", param_array[r][c] , " received:", result_array[r][c])
                         success = False
 
+        try:
+            result_array = self.cursor.execute("exec SelectTVP ?", [[]])
+        except Exception as ex:
+            print("Failed to execute SelectTVP")
+            print("Exception: [" + type(ex).__name__ + "]" , ex.args)
+            success = False
+
         self.assertEqual(success, True)
         
 def main():


### PR DESCRIPTION
If the columns of a table-valued parameter are not bound, the
Python interpreter will crash, even if the value passed for
the invocation of the stored procedure has no rows. According
to Microsoft's documentation:

> After binding the table-valued parameter, the application
> must then bind each table-valued parameter column.
> 

Closes #772