### PR TITLE
Setup.py drop Py34 and add Py37 Py38

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,9 +102,10 @@ def main():
                        'Programming Language :: Python :: 2',
                        'Programming Language :: Python :: 2.7',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.4',
                        'Programming Language :: Python :: 3.5',
                        'Programming Language :: Python :: 3.6',
+                       'Programming Language :: Python :: 3.7',
+                       'Programming Language :: Python :: 3.8',
                        'Topic :: Database',
                        ],
 


### PR DESCRIPTION
Looking at the pyodbc [PyPi](https://pypi.org/project/pyodbc/) page, it appears as if pyodbc does not support Python 3.7 and 3.8.  This is not correct.  Also, it doesn't seem unreasonable to drop official Python 3.4 support, after all it's rather old now.