### PR TITLE
Tell the driver to use the default value for an empty TVP

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1436,7 +1436,7 @@ bool BindParameter(Cursor* cur, Py_ssize_t index, ParamInfo& info)
 
         Py_ssize_t i = PySequence_Size(info.pObject) - info.ColumnSize;
         Py_ssize_t ncols = 0;
-        while (i < PySequence_Size(info.pObject))
+        while (i >= 0 && i < PySequence_Size(info.pObject))
         {
             PyObject *row = PySequence_GetItem(info.pObject, i);
             Py_XDECREF(row);
@@ -1459,6 +1459,7 @@ bool BindParameter(Cursor* cur, Py_ssize_t index, ParamInfo& info)
         {
             // TVP has no columns --- is null
             info.nested = 0;
+            info.StrLen_or_Ind = SQL_DEFAULT_PARAM;
         }
         else
         {

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1863,6 +1863,14 @@ class SqlServerTestCase(unittest.TestCase):
                         print("Mismatch at row " + str(r+1) + ", column " + str(c+1) + "; expected:", param_array[r][c] , " received:", result_array[r][c])
                         success = False
 
+        try:
+            result_array = self.cursor.execute("exec SelectTVP ?", [[]]).fetchall()
+            self.assertEqual(result_array, [])
+        except Exception as ex:
+            print("Failed to execute SelectTVP")
+            print("Exception: [" + type(ex).__name__ + "]", ex.args)
+            success = False
+
         self.assertEqual(success, True)
 
 

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1789,6 +1789,14 @@ class SqlServerTestCase(unittest.TestCase):
                         print("Mismatch at row " + str(r+1) + ", column " + str(c+1) + "; expected:", param_array[r][c] , " received:", result_array[r][c])
                         success = False
 
+        try:
+            result_array = self.cursor.execute("exec SelectTVP ?", [[]]).fetchall()
+            self.assertEqual(result_array, [])
+        except Exception as ex:
+            print("Failed to execute SelectTVP")
+            print("Exception: [" + type(ex).__name__ + "]", ex.args)
+            success = False
+
         self.assertEqual(success, True)
         
 def main():


### PR DESCRIPTION
Without this patch, passing a TVP with no rows will crash
the Python interpreter. Solution from v-chojas.

See https://github.com/mkleehammer/pyodbc/issues/772.

Closes #722.