### PR TITLE
Don't use PyUnicode_Encode API

### DIFF
--- a/src/cnxninfo.cpp
+++ b/src/cnxninfo.cpp
@@ -42,7 +42,7 @@ bool CnxnInfo_init()
 static PyObject* GetHash(PyObject* p)
 {
 #if PY_MAJOR_VERSION >= 3
-    Object bytes(PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(p), PyUnicode_GET_SIZE(p), 0));
+    Object bytes(PyUnicode_AsUTF8String(p));
     if (!bytes)
         return 0;
     p = bytes.Get();

--- a/src/errors.h
+++ b/src/errors.h
@@ -61,7 +61,7 @@ inline PyObject* RaiseErrorFromException(PyObject* pError)
 #if PY_MAJOR_VERSION >= 3
     PyErr_SetObject((PyObject*)Py_TYPE(pError), pError);
 #else
-	PyObject* cls = (PyObject*)((PyInstance_Check(pError) ? (PyObject*)((PyInstanceObject*)pError)->in_class : (PyObject*)(Py_TYPE(pError))));
+    PyObject* cls = (PyObject*)((PyInstance_Check(pError) ? (PyObject*)((PyInstanceObject*)pError)->in_class : (PyObject*)(Py_TYPE(pError))));
     PyErr_SetObject(cls, pError);
 #endif
     return 0;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1921,9 +1921,10 @@ bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj)
                 if (PyUnicode_Check(objCell))
                 {
                     const TextEnc& enc = cur->cnxn->sqlwchar_enc;
-                    int cb = PyUnicode_GET_DATA_SIZE(objCell) / 2;
-
                     PyObject* bytes = NULL;
+
+#if PY_MAJOR_VERSION < 3
+                    int cb = PyUnicode_GET_DATA_SIZE(objCell) / 2;
                     const Py_UNICODE* source = PyUnicode_AS_UNICODE(objCell);
 
                     switch (enc.optenc)
@@ -1941,11 +1942,28 @@ bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj)
                         bytes = PyUnicode_EncodeUTF16(source, cb, "strict", BYTEORDER_BE);
                         break;
                     }
-
+#else
+                    switch (enc.optenc)
+                    {
+                    case OPTENC_UTF8:
+                        bytes = PyUnicode_AsUTF8String(objCell);
+                        break;
+                    case OPTENC_UTF16:
+                        bytes = PyUnicode_AsUTF16String(objCell);
+                        break;
+                    case OPTENC_UTF16LE:
+                        bytes = PyUnicode_AsEncodedString(objCell, "utf_16_le", NULL);
+                        break;
+                    case OPTENC_UTF16BE:
+                        bytes = PyUnicode_AsEncodedString(objCell, "utf_16_be", NULL);
+                        break;
+                    }
+#endif
                     if (bytes && PyBytes_Check(bytes))
                     {
                         objCell = bytes;
                     }
+                    //TODO: Raise or clear error when bytes == NULL.
                 }
 
                 szLastFunction = "SQLPutData";


### PR DESCRIPTION
PyUnicode_EncodeUTF8 is deprecated, and PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(p), ...) is inefficient.