### PR TITLE
Move Travis unit test code to the correct function

### DIFF
--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -622,7 +622,15 @@ class PGTestCase(unittest.TestCase):
 
         result = self.cursor.execute("select s from t1").fetchone()[0]
 
-        self.assertEqual(result, v)
+        if os.getenv('CI') == 'true' and os.getenv('TRAVIS') == 'true':
+            # On the current Travis CI platform (i.e. Ubuntu), this test generates the wrong
+            # result, which appears to be a PostgreSQL issue.  A bug report has been raised
+            # with PostgreSQL: https://www.postgresql.org/message-id/16469-11c82a64f17f51f4%40postgresql.org
+            # Nevertheless, the result is predictable so we will still test for that incorrect value.
+            # This ensures the build passes and if this behavior ever changes, we will know about it.
+            self.assertEqual(result, v.encode('utf-8').decode('latin-1'))
+        else:
+            self.assertEqual(result, v)
 
     def test_cursor_messages(self):
         """
@@ -652,15 +660,6 @@ class PGTestCase(unittest.TestCase):
         self.assertTrue(type(self.cursor.messages[0][1]) is str)
         self.assertEqual('[01000] (-1)', self.cursor.messages[0][0])
         self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
-        if os.getenv('CI') == 'true' and os.getenv('TRAVIS') == 'true':
-            # On the current Travis CI platform (i.e. Ubuntu), this test generates the wrong
-            # result, which appears to be a PostgreSQL issue.  A bug report has been raised
-            # with PostgreSQL: https://www.postgresql.org/message-id/16469-11c82a64f17f51f4%40postgresql.org
-            # Nevertheless, the result is predictable so we will still test for that incorrect value.
-            # This ensures the build passes and if this behavior ever changes, we will know about it.
-            self.assertEqual(result, v.encode('utf-8').decode('latin-1'))
-        else:
-            self.assertEqual(result, v)
 
     def test_output_conversion(self):
         # Note the use of SQL_WVARCHAR, not SQL_VARCHAR.


### PR DESCRIPTION
As part of the merge of PR 773, some code in one of the unit tests ended up in a different unit test, causing the Travis CI tests to fail.  This PR fixes that.  The Travis CI tests should now pass.