### PR TITLE
Fix timestamp fraction digits conversion for DecimalDigits larger than 10

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -403,9 +403,10 @@ static int PyToCType(Cursor *cur, unsigned char **outbuf, PyObject *cell, ParamI
         pts->second = PyDateTime_DATE_GET_SECOND(cell);
 
         // Truncate the fraction according to precision
-        long fast_pow10[] = {1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000, 10000000000};
+        size_t digits = min(9, pi->DecimalDigits);
+        long fast_pow10[] = {1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000};
         SQLUINTEGER milliseconds = PyDateTime_DATE_GET_MICROSECOND(cell) * 1000;
-        pts->fraction = milliseconds - (milliseconds % fast_pow10[10 - pi->DecimalDigits]);
+        pts->fraction = milliseconds - (milliseconds % fast_pow10[9 - digits]);
 
         *outbuf += sizeof(SQL_TIMESTAMP_STRUCT);
         ind = sizeof(SQL_TIMESTAMP_STRUCT);

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -403,9 +403,9 @@ static int PyToCType(Cursor *cur, unsigned char **outbuf, PyObject *cell, ParamI
         pts->second = PyDateTime_DATE_GET_SECOND(cell);
 
         // Truncate the fraction according to precision
-        long fast_pow10[] = {1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000};
+        long fast_pow10[] = {1,10,100,1000,10000,100000,1000000,10000000,100000000,1000000000, 10000000000};
         SQLUINTEGER milliseconds = PyDateTime_DATE_GET_MICROSECOND(cell) * 1000;
-        pts->fraction = milliseconds - (milliseconds % fast_pow10[9 - pi->DecimalDigits]);
+        pts->fraction = milliseconds - (milliseconds % fast_pow10[10 - pi->DecimalDigits]);
 
         *outbuf += sizeof(SQL_TIMESTAMP_STRUCT);
         ind = sizeof(SQL_TIMESTAMP_STRUCT);


### PR DESCRIPTION
For some reason, when using MS SQL Server ODBC Driver 17, against MS SQL Server 17, the `DecimalDigits` param info value is `10`, giving negative index in fast_pow10, thus making array access out of bounds.

In most situations, this would give us a garbage value and likely "truncate" the fraction. In my particular case, the garbage value was `0`, raising a division by zero FPE.

This PR is a quick fix, by adding a 10th element in fast_pow10. A more "robust" solution would be to add a "slow" version if `DecimalDigits > 10` as a fallback.