### PR TITLE
Fix segmentation fault from GetDiagRecs()

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -573,7 +573,7 @@ static int GetDiagRecs(Cursor* cur)
     SQLSMALLINT iRecNumber = 1;  // the index of the diagnostic records (1-based)
     ODBCCHAR    cSQLState[6];  // five-character SQLSTATE code (plus terminating NULL)
     SQLINTEGER  iNativeError;
-    ODBCCHAR    cMessageText[10241];  // PRINT statements can be large, hopefully 10K bytes will be enough
+    ODBCCHAR    cMessageText[10001];  // PRINT statements can be large, hopefully 10K bytes will be enough
     SQLSMALLINT iTextLength;
 
     SQLRETURN ret;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -568,17 +568,16 @@ static int GetDiagRecs(Cursor* cur)
 {
     // Retrieves all diagnostic records from the cursor and assigns them to the "messages" attribute.
 
-    PyObject* msg_list;
+    PyObject* msg_list;  // the "messages" as a Python list of diagnostic records
 
-    SQLSMALLINT iRecNumber = 1;
-
+    SQLSMALLINT iRecNumber = 1;  // the index of the diagnostic records (1-based)
     ODBCCHAR    cSQLState[6];  // five-character SQLSTATE code (plus terminating NULL)
     SQLINTEGER  iNativeError;
-    ODBCCHAR    cMessageText[10240];  // PRINT statements can be large, hopefully 10K bytes will be enough
+    ODBCCHAR    cMessageText[10241];  // PRINT statements can be large, hopefully 10K bytes will be enough
     SQLSMALLINT iTextLength;
 
     SQLRETURN ret;
-    char sqlstate_ascii[6] = "";  //  ASCII version of the SQLState
+    char sqlstate_ascii[6] = "";  // ASCII version of the SQLState
 
     msg_list = PyList_New(0);
     if (!msg_list)
@@ -616,7 +615,7 @@ static int GetDiagRecs(Cursor* cur)
             msg_value = PyBytes_FromStringAndSize((char*)cMessageText, iTextLength * sizeof(ODBCCHAR));
         }
 
-        PyObject* msg_tuple = PyTuple_New(2);
+        PyObject* msg_tuple = PyTuple_New(2);  // the message as a Python tuple of class and value
 
         if (msg_class && msg_value && msg_tuple)
         {
@@ -638,6 +637,8 @@ static int GetDiagRecs(Cursor* cur)
 
     Py_XDECREF(cur->messages);
     cur->messages = msg_list;  // cur->messages now owns the msg_list reference
+
+    return 0;
 }
 
 


### PR DESCRIPTION
This PR should fix the segmentation fault described in #858 .  Function GetDiagRecs() should always return an integer otherwise the stack can become corrupted.  Still not sure why this impacted only RedHat and Oracle Linux distributions but it has to be fixed regardless.  I tested this on a RedHat 8.3 instance.

Whilst we're here, add one to the size of the MessageText string for the terminating NULL character.  Also, add more comments.