### PR TITLE
Add dynamic buffers in GetDiagRecs and GetErrorFromHandle and prevent buffer overflow on errors longer than 1024 characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,10 @@ def main():
 
         'ext_modules': [Extension('pyodbc', sorted(files), **settings)],
 
+        'data_files': [
+            ('', ['src/pyodbc.pyi'])  # places pyodbc.pyi alongside pyodbc.py in site-packages
+        ],
+
         'license': 'MIT',
 
         'classifiers': ['Development Status :: 5 - Production/Stable',

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -574,7 +574,7 @@ static int GetDiagRecs(Cursor* cur)
 
     ODBCCHAR    cSQLState[6];  // five-character SQLSTATE code (plus terminating NULL)
     SQLINTEGER  iNativeError;
-    ODBCCHAR    cMessageText[SHRT_MAX];  // PRINT statements can be large
+    ODBCCHAR    cMessageText[10240];  // PRINT statements can be large
     SQLSMALLINT iTextLength;
 
     SQLRETURN ret;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -574,7 +574,7 @@ static int GetDiagRecs(Cursor* cur)
 
     ODBCCHAR    cSQLState[6];  // five-character SQLSTATE code (plus terminating NULL)
     SQLINTEGER  iNativeError;
-    ODBCCHAR    cMessageText[10240];  // PRINT statements can be large, hopefully 10K bytes will be enough
+    ODBCCHAR    cMessageText[SHRT_MAX];  // PRINT statements can be large
     SQLSMALLINT iTextLength;
 
     SQLRETURN ret;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -568,10 +568,9 @@ static int GetDiagRecs(Cursor* cur)
 {
     // Retrieves all diagnostic records from the cursor and assigns them to the "messages" attribute.
 
-    PyObject* msg_list;
+    PyObject* msg_list;  // the "messages" as a Python list of diagnostic records
 
-    SQLSMALLINT iRecNumber = 1;
-
+    SQLSMALLINT iRecNumber = 1;  // the index of the diagnostic records (1-based)
     ODBCCHAR    cSQLState[6];  // five-character SQLSTATE code (plus terminating NULL)
     SQLINTEGER  iNativeError;
     SQLSMALLINT iMessageLen = 1023;
@@ -579,7 +578,7 @@ static int GetDiagRecs(Cursor* cur)
     SQLSMALLINT iTextLength;
 
     SQLRETURN ret;
-    char sqlstate_ascii[6] = "";  //  ASCII version of the SQLState
+    char sqlstate_ascii[6] = "";  // ASCII version of the SQLState
 
     if (!cMessageText) {
         return 0;
@@ -638,7 +637,7 @@ static int GetDiagRecs(Cursor* cur)
             msg_value = PyBytes_FromStringAndSize((char*)cMessageText, iTextLength * sizeof(ODBCCHAR));
         }
 
-        PyObject* msg_tuple = PyTuple_New(2);
+        PyObject* msg_tuple = PyTuple_New(2);  // the message as a Python tuple of class and value
 
         if (msg_class && msg_value && msg_tuple)
         {
@@ -661,6 +660,8 @@ static int GetDiagRecs(Cursor* cur)
 
     Py_XDECREF(cur->messages);
     cur->messages = msg_list;  // cur->messages now owns the msg_list reference
+
+    return 0;
 }
 
 

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -574,11 +574,16 @@ static int GetDiagRecs(Cursor* cur)
 
     ODBCCHAR    cSQLState[6];  // five-character SQLSTATE code (plus terminating NULL)
     SQLINTEGER  iNativeError;
-    ODBCCHAR    cMessageText[10240];  // PRINT statements can be large
+    SQLSMALLINT iMessageLen = 1023;
+    ODBCCHAR    *cMessageText = (ODBCCHAR*) pyodbc_malloc((iMessageLen + 1) * sizeof(ODBCCHAR));
     SQLSMALLINT iTextLength;
 
     SQLRETURN ret;
     char sqlstate_ascii[6] = "";  //  ASCII version of the SQLState
+
+    if (!cMessageText) {
+        return 0;
+    }
 
     msg_list = PyList_New(0);
     if (!msg_list)
@@ -594,11 +599,28 @@ static int GetDiagRecs(Cursor* cur)
         Py_BEGIN_ALLOW_THREADS
         ret = SQLGetDiagRecW(
             SQL_HANDLE_STMT, cur->hstmt, iRecNumber, (SQLWCHAR*)cSQLState, &iNativeError,
-            (SQLWCHAR*)cMessageText, (short)(_countof(cMessageText)-1), &iTextLength
+            (SQLWCHAR*)cMessageText, iMessageLen, &iTextLength
         );
         Py_END_ALLOW_THREADS
         if (!SQL_SUCCEEDED(ret))
             break;
+
+        // If needed, allocate a bigger error message buffer and retry.
+        if (iTextLength > iMessageLen - 1) {
+            iMessageLen = iTextLength + 1;
+            if (!pyodbc_realloc((BYTE**) &cMessageText, (iMessageLen + 1) * sizeof(ODBCCHAR))) {
+                pyodbc_free(cMessageText);
+                return 0;
+            }
+            Py_BEGIN_ALLOW_THREADS
+            ret = SQLGetDiagRecW(
+                SQL_HANDLE_STMT, cur->hstmt, iRecNumber, (SQLWCHAR*)cSQLState, &iNativeError,
+                (SQLWCHAR*)cMessageText, iMessageLen, &iTextLength
+            );
+            Py_END_ALLOW_THREADS
+            if (!SQL_SUCCEEDED(ret))
+                break;
+        }
 
         cSQLState[5] = 0;  // Not always NULL terminated (MS Access)
         CopySqlState(cSQLState, sqlstate_ascii);
@@ -635,6 +657,7 @@ static int GetDiagRecs(Cursor* cur)
 
         iRecNumber++;
     }
+    pyodbc_free(cMessageText);
 
     Py_XDECREF(cur->messages);
     cur->messages = msg_list;  // cur->messages now owns the msg_list reference

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -581,7 +581,8 @@ static int GetDiagRecs(Cursor* cur)
     char sqlstate_ascii[6] = "";  // ASCII version of the SQLState
 
     if (!cMessageText) {
-        return 0;
+      PyErr_NoMemory();
+      return 0;
     }
 
     msg_list = PyList_New(0);
@@ -609,6 +610,7 @@ static int GetDiagRecs(Cursor* cur)
             iMessageLen = iTextLength + 1;
             if (!pyodbc_realloc((BYTE**) &cMessageText, (iMessageLen + 1) * sizeof(ODBCCHAR))) {
                 pyodbc_free(cMessageText);
+                PyErr_NoMemory();
                 return 0;
             }
             Py_BEGIN_ALLOW_THREADS

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -217,7 +217,7 @@ PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc
     SQLSMALLINT cchMsg;
 
     ODBCCHAR sqlstateT[6];
-    ODBCCHAR szMsg[1024];
+    ODBCCHAR szMsg[SHRT_MAX];
 
     if (hstmt != SQL_NULL_HANDLE)
     {
@@ -317,14 +317,11 @@ PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc
 
 static bool GetSqlState(HSTMT hstmt, char* szSqlState)
 {
-    SQLCHAR szMsg[300];
-    SQLSMALLINT cbMsg = (SQLSMALLINT)(_countof(szMsg) - 1);
-    SQLINTEGER nNative;
     SQLSMALLINT cchMsg;
     SQLRETURN ret;
 
     Py_BEGIN_ALLOW_THREADS
-    ret = SQLGetDiagRec(SQL_HANDLE_STMT, hstmt, 1, (SQLCHAR*)szSqlState, &nNative, szMsg, cbMsg, &cchMsg);
+    ret = SQLGetDiagField(SQL_HANDLE_STMT, hstmt, 1, SQL_DIAG_SQLSTATE, (SQLCHAR*)szSqlState, 5, &cchMsg);
     Py_END_ALLOW_THREADS
     return SQL_SUCCEEDED(ret);
 }

--- a/src/pyodbc.h
+++ b/src/pyodbc.h
@@ -148,6 +148,10 @@ inline void DebugTrace(const char* szFmt, ...) { UNUSED(szFmt); }
 #define pyodbc_free free
 // #endif
 
+// issue #880: entry missing from iODBC sqltypes.h
+#ifndef BYTE
+  typedef unsigned char		BYTE;
+#endif
 bool pyodbc_realloc(BYTE** pp, size_t newlen);
 // A wrapper around realloc with a safer interface.  If it is successful, *pp is updated to the
 // new pointer value.  If not successful, it is not modified.  (It is easy to forget and lose

--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -1,0 +1,414 @@
+from __future__ import annotations
+from typing import Any, Callable, Dict, Generator, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union
+
+_TV = TypeVar('_TV')  # represents any class, for the cursor description "type_code" attribute
+
+
+# ODBC connection attributes
+SQL_ACCESS_MODE: int
+SQL_AUTOCOMMIT: int
+SQL_LOGIN_TIMEOUT: int
+SQL_OPT_TRACE: int
+SQL_OPT_TRACEFILE: int
+SQL_TRANSLATE_DLL: int
+SQL_TRANSLATE_OPTION: int
+SQL_TXN_ISOLATION: int
+SQL_CURRENT_QUALIFIER: int
+SQL_ODBC_CURSORS: int
+SQL_QUIET_MODE: int
+SQL_PACKET_SIZE: int
+SQL_ATTR_ACCESS_MODE: int
+SQL_ATTR_AUTOCOMMIT: int
+SQL_ATTR_LOGIN_TIMEOUT: int
+SQL_ATTR_TRACE: int
+SQL_ATTR_TRACEFILE: int
+SQL_ATTR_TRANSLATE_LIB: int
+SQL_ATTR_TRANSLATE_OPTION: int
+SQL_ATTR_TXN_ISOLATION: int
+SQL_ATTR_CURRENT_CATALOG: int
+SQL_ATTR_ODBC_CURSORS: int
+SQL_ATTR_QUIET_MODE: int
+SQL_ATTR_ANSI_APP: int
+
+# ODBC column data types
+# https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/appendix-d-data-types
+SQL_WMETADATA: int
+SQL_UNKNOWN_TYPE: int
+SQL_CHAR: int
+SQL_VARCHAR: int
+SQL_LONGVARCHAR: int
+SQL_WCHAR: int
+SQL_WVARCHAR: int
+SQL_WLONGVARCHAR: int
+SQL_DECIMAL: int
+SQL_NUMERIC: int
+SQL_SMALLINT: int
+SQL_INTEGER: int
+SQL_REAL: int
+SQL_FLOAT: int
+SQL_DOUBLE: int
+SQL_BIT: int
+SQL_TINYINT: int
+SQL_BIGINT: int
+SQL_BINARY: int
+SQL_VARBINARY: int
+SQL_LONGVARBINARY: int
+SQL_TYPE_DATE: int
+SQL_TYPE_TIME: int
+SQL_TYPE_TIMESTAMP: int
+SQL_SS_TIME2: int
+SQL_SS_XML: int
+SQL_INTERVAL_MONTH: int
+SQL_INTERVAL_YEAR: int
+SQL_INTERVAL_YEAR_TO_MONTH: int
+SQL_INTERVAL_DAY: int
+SQL_INTERVAL_HOUR: int
+SQL_INTERVAL_MINUTE: int
+SQL_INTERVAL_SECOND: int
+SQL_INTERVAL_DAY_TO_HOUR: int
+SQL_INTERVAL_DAY_TO_MINUTE: int
+SQL_INTERVAL_DAY_TO_SECOND: int
+SQL_INTERVAL_HOUR_TO_MINUTE: int
+SQL_INTERVAL_HOUR_TO_SECOND: int
+SQL_INTERVAL_MINUTE_TO_SECOND: int
+SQL_GUID: int
+SQL_NULLABLE: int
+SQL_NO_NULLS: int
+SQL_NULLABLE_UNKNOWN: int
+
+# SQL_CONVERT_X
+SQL_CONVERT_FUNCTIONS: int
+SQL_CONVERT_BIGINT: int
+SQL_CONVERT_BINARY: int
+SQL_CONVERT_BIT: int
+SQL_CONVERT_CHAR: int
+SQL_CONVERT_DATE: int
+SQL_CONVERT_DECIMAL: int
+SQL_CONVERT_DOUBLE: int
+SQL_CONVERT_FLOAT: int
+SQL_CONVERT_GUID: int
+SQL_CONVERT_INTEGER: int
+SQL_CONVERT_INTERVAL_DAY_TIME: int
+SQL_CONVERT_INTERVAL_YEAR_MONTH: int
+SQL_CONVERT_LONGVARBINARY: int
+SQL_CONVERT_LONGVARCHAR: int
+SQL_CONVERT_NUMERIC: int
+SQL_CONVERT_REAL: int
+SQL_CONVERT_SMALLINT: int
+SQL_CONVERT_TIME: int
+SQL_CONVERT_TIMESTAMP: int
+SQL_CONVERT_TINYINT: int
+SQL_CONVERT_VARBINARY: int
+SQL_CONVERT_VARCHAR: int
+SQL_CONVERT_WCHAR: int
+SQL_CONVERT_WLONGVARCHAR: int
+SQL_CONVERT_WVARCHAR: int
+
+# SQLSetConnectAttr transaction isolation
+SQL_ATTR_TXN_ISOLATION: int
+SQL_TXN_READ_UNCOMMITTED: int
+SQL_TXN_READ_COMMITTED: int
+SQL_TXN_REPEATABLE_READ: int
+SQL_TXN_SERIALIZABLE: int
+
+## outer join capabilities
+SQL_OJ_LEFT: int
+SQL_OJ_RIGHT: int
+SQL_OJ_FULL: int
+SQL_OJ_NESTED: int
+SQL_OJ_NOT_ORDERED: int
+SQL_OJ_INNER: int
+SQL_OJ_ALL_COMPARISON_OPS: int
+
+# other ODBC database constants
+SQL_SCOPE_CURROW: int
+SQL_SCOPE_TRANSACTION: int
+SQL_SCOPE_SESSION: int
+SQL_PC_UNKNOWN: int
+SQL_PC_NOT_PSEUDO: int
+SQL_PC_PSEUDO: int
+# SQL_INDEX_BTREE: int
+# SQL_INDEX_CLUSTERED: int
+# SQL_INDEX_CONTENT: int
+# SQL_INDEX_HASHED: int
+# SQL_INDEX_OTHER: int
+
+# attributes for the ODBC SQLGetInfo function
+# https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetinfo-function
+SQL_ACCESSIBLE_PROCEDURES: int
+SQL_ACCESSIBLE_TABLES: int
+SQL_ACTIVE_ENVIRONMENTS: int
+SQL_AGGREGATE_FUNCTIONS: int
+SQL_ALTER_DOMAIN: int
+SQL_ALTER_TABLE: int
+SQL_ASYNC_MODE: int
+SQL_BATCH_ROW_COUNT: int
+SQL_BATCH_SUPPORT: int
+SQL_BOOKMARK_PERSISTENCE: int
+SQL_CATALOG_LOCATION: int
+SQL_CATALOG_NAME: int
+SQL_CATALOG_NAME_SEPARATOR: int
+SQL_CATALOG_TERM: int
+SQL_CATALOG_USAGE: int
+SQL_COLLATION_SEQ: int
+SQL_COLUMN_ALIAS: int
+SQL_CONCAT_NULL_BEHAVIOR: int
+SQL_CONVERT_VARCHAR: int
+SQL_CORRELATION_NAME: int
+SQL_CREATE_ASSERTION: int
+SQL_CREATE_CHARACTER_SET: int
+SQL_CREATE_COLLATION: int
+SQL_CREATE_DOMAIN: int
+SQL_CREATE_SCHEMA: int
+SQL_CREATE_TABLE: int
+SQL_CREATE_TRANSLATION: int
+SQL_CREATE_VIEW: int
+SQL_CURSOR_COMMIT_BEHAVIOR: int
+SQL_CURSOR_ROLLBACK_BEHAVIOR: int
+# SQL_CURSOR_ROLLBACK_SQL_CURSOR_SENSITIVITY: int
+SQL_DATABASE_NAME: int
+SQL_DATA_SOURCE_NAME: int
+SQL_DATA_SOURCE_READ_ONLY: int
+SQL_DATETIME_LITERALS: int
+SQL_DBMS_NAME: int
+SQL_DBMS_VER: int
+SQL_DDL_INDEX: int
+SQL_DEFAULT_TXN_ISOLATION: int
+SQL_DESCRIBE_PARAMETER: int
+SQL_DM_VER: int
+SQL_DRIVER_HDESC: int
+SQL_DRIVER_HENV: int
+SQL_DRIVER_HLIB: int
+SQL_DRIVER_HSTMT: int
+SQL_DRIVER_NAME: int
+SQL_DRIVER_ODBC_VER: int
+SQL_DRIVER_VER: int
+SQL_DROP_ASSERTION: int
+SQL_DROP_CHARACTER_SET: int
+SQL_DROP_COLLATION: int
+SQL_DROP_DOMAIN: int
+SQL_DROP_SCHEMA: int
+SQL_DROP_TABLE: int
+SQL_DROP_TRANSLATION: int
+SQL_DROP_VIEW: int
+SQL_DYNAMIC_CURSOR_ATTRIBUTES1: int
+SQL_DYNAMIC_CURSOR_ATTRIBUTES2: int
+SQL_EXPRESSIONS_IN_ORDERBY: int
+SQL_FILE_USAGE: int
+SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1: int
+SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2: int
+SQL_GETDATA_EXTENSIONS: int
+SQL_GROUP_BY: int
+SQL_IDENTIFIER_CASE: int
+SQL_IDENTIFIER_QUOTE_CHAR: int
+SQL_INDEX_KEYWORDS: int
+SQL_INFO_SCHEMA_VIEWS: int
+SQL_INSERT_STATEMENT: int
+SQL_INTEGRITY: int
+SQL_KEYSET_CURSOR_ATTRIBUTES1: int
+SQL_KEYSET_CURSOR_ATTRIBUTES2: int
+SQL_KEYWORDS: int
+SQL_LIKE_ESCAPE_CLAUSE: int
+SQL_MAX_ASYNC_CONCURRENT_STATEMENTS: int
+SQL_MAX_BINARY_LITERAL_LEN: int
+SQL_MAX_CATALOG_NAME_LEN: int
+SQL_MAX_CHAR_LITERAL_LEN: int
+SQL_MAX_COLUMNS_IN_GROUP_BY: int
+SQL_MAX_COLUMNS_IN_INDEX: int
+SQL_MAX_COLUMNS_IN_ORDER_BY: int
+SQL_MAX_COLUMNS_IN_SELECT: int
+SQL_MAX_COLUMNS_IN_TABLE: int
+SQL_MAX_COLUMN_NAME_LEN: int
+SQL_MAX_CONCURRENT_ACTIVITIES: int
+SQL_MAX_CURSOR_NAME_LEN: int
+SQL_MAX_DRIVER_CONNECTIONS: int
+SQL_MAX_IDENTIFIER_LEN: int
+SQL_MAX_INDEX_SIZE: int
+SQL_MAX_PROCEDURE_NAME_LEN: int
+SQL_MAX_ROW_SIZE: int
+SQL_MAX_ROW_SIZE_INCLUDES_LONG: int
+SQL_MAX_SCHEMA_NAME_LEN: int
+SQL_MAX_STATEMENT_LEN: int
+SQL_MAX_TABLES_IN_SELECT: int
+SQL_MAX_TABLE_NAME_LEN: int
+SQL_MAX_USER_NAME_LEN: int
+SQL_MULTIPLE_ACTIVE_TXN: int
+SQL_MULT_RESULT_SETS: int
+SQL_NEED_LONG_DATA_LEN: int
+SQL_NON_NULLABLE_COLUMNS: int
+SQL_NULL_COLLATION: int
+SQL_NUMERIC_FUNCTIONS: int
+SQL_ODBC_INTERFACE_CONFORMANCE: int
+SQL_ODBC_VER: int
+SQL_OJ_CAPABILITIES: int
+SQL_ORDER_BY_COLUMNS_IN_SELECT: int
+SQL_PARAM_ARRAY_ROW_COUNTS: int
+SQL_PARAM_ARRAY_SELECTS: int
+SQL_PARAM_TYPE_UNKNOWN: int
+SQL_PARAM_INPUT: int
+SQL_PARAM_INPUT_OUTPUT: int
+SQL_PARAM_OUTPUT: int
+SQL_RETURN_VALUE: int
+SQL_RESULT_COL: int
+SQL_PROCEDURES: int
+SQL_PROCEDURE_TERM: int
+SQL_QUOTED_IDENTIFIER_CASE: int
+SQL_ROW_UPDATES: int
+SQL_SCHEMA_TERM: int
+SQL_SCHEMA_USAGE: int
+SQL_SCROLL_OPTIONS: int
+SQL_SEARCH_PATTERN_ESCAPE: int
+SQL_SERVER_NAME: int
+SQL_SPECIAL_CHARACTERS: int
+SQL_SQL92_DATETIME_FUNCTIONS: int
+SQL_SQL92_FOREIGN_KEY_DELETE_RULE: int
+SQL_SQL92_FOREIGN_KEY_UPDATE_RULE: int
+SQL_SQL92_GRANT: int
+SQL_SQL92_NUMERIC_VALUE_FUNCTIONS: int
+SQL_SQL92_PREDICATES: int
+SQL_SQL92_RELATIONAL_JOIN_OPERATORS: int
+SQL_SQL92_REVOKE: int
+SQL_SQL92_ROW_VALUE_CONSTRUCTOR: int
+SQL_SQL92_STRING_FUNCTIONS: int
+SQL_SQL92_VALUE_EXPRESSIONS: int
+SQL_SQL_CONFORMANCE: int
+SQL_STANDARD_CLI_CONFORMANCE: int
+SQL_STATIC_CURSOR_ATTRIBUTES1: int
+SQL_STATIC_CURSOR_ATTRIBUTES2: int
+SQL_STRING_FUNCTIONS: int
+SQL_SUBQUERIES: int
+SQL_SYSTEM_FUNCTIONS: int
+SQL_TABLE_TERM: int
+SQL_TIMEDATE_ADD_INTERVALS: int
+SQL_TIMEDATE_DIFF_INTERVALS: int
+SQL_TIMEDATE_FUNCTIONS: int
+SQL_TXN_CAPABLE: int
+SQL_TXN_ISOLATION_OPTION: int
+SQL_UNION: int
+SQL_USER_NAME: int
+SQL_XOPEN_CLI_YEAR: int
+
+
+# pyodbc-specific constants
+BinaryNull: Any  # to distinguish binary NULL values from char NULL values
+
+# read-only module attributes
+version: str
+# https://www.python.org/dev/peps/pep-0249/#globals
+apilevel: str
+threadsafety: int
+paramstyle: str
+
+# read-write module attributes
+pooling: bool
+lowercase: bool
+native_uuid: bool
+
+
+# exceptions
+# https://www.python.org/dev/peps/pep-0249/#exceptions
+class Warning(Exception): ...
+class Error(Exception): ...
+class DatabaseError(Error): ...
+class DataError(DatabaseError): ...
+class OperationalError(DatabaseError): ...
+class IntegrityError(DatabaseError): ...
+class InternalError(DatabaseError): ...
+class ProgrammingError(DatabaseError): ...
+class NotSupportedError(DatabaseError): ...
+
+
+# an ODBC connection to the database, in part manages database transactions
+# https://www.python.org/dev/peps/pep-0249/#connection-objects
+class Connection:
+
+    # read-write attributes
+    autocommit: bool
+    maxwrite: int
+    timeout: int
+
+    # read-only attributes
+    searchescape: str
+
+    def setencoding(self, encoding: str, ctype: Optional[int]) -> None: ...
+    def setdecoding(self, encoding: str, ctype: Optional[int]) -> None: ...
+
+    def getinfo(self, infotype: int, /) -> Any: ...
+    def set_attr(self, attr_id: int, value: int, /) -> None: ...
+
+    def add_output_converter(self, sqltype: int, new_converter: Callable, /) -> None: ...
+    def get_output_converter(self, sqltype: int, /) -> Optional[Callable]: ...
+    def remove_output_converter(self, sqltype: int, /) -> None: ...
+    def clear_output_converters(self) -> None: ...
+
+    def cursor(self) -> Cursor: ...
+    def execute(self, sql: str, *params) -> Cursor: ...
+    def commit(self) -> None: ...
+    def rollback(self) -> None: ...
+    def close(self) -> None: ...
+
+
+# cursors are vehicles for executing SQL statements and returning their results
+# https://www.python.org/dev/peps/pep-0249/#cursor-objects
+class Cursor:
+
+    # read-write attributes
+    arraysize: int
+    fast_executemany: bool
+    noscan: bool
+
+    # read-only attributes
+    description: Tuple[Tuple[str, _TV, int, int, int, int, bool]]
+    messages: Optional[List[Tuple[str, Union[str, bytes]]]]
+    rowcount: int
+    connection: Connection
+
+    def setinputsizes(self, sizes: List[Tuple[int, int, int]], /) -> None: ...
+    def setoutputsize(self) -> None: ...
+    def execute(self, sql: str, *params) -> Cursor: ...
+    def executemany(self, sql: str, params: Union[Sequence, Iterator, Generator], /) -> None: ...
+    def fetchone(self) -> Row: ...
+    def fetchmany(self, size: int, /) -> List[Row]: ...
+    def fetchall(self) -> List[Row]: ...
+    def fetchval(self) -> Any: ...
+    def skip(self, count: int, /) -> None: ...
+    def nextset(self) -> bool: ...
+    def commit(self) -> None: ...
+    def rollback(self) -> None: ...
+    def cancel(self) -> None: ...
+    def close(self) -> None: ...
+
+    def tables(self) -> Cursor: ...
+    def columns(self) -> Cursor: ...
+    def statistics(self) -> Cursor: ...
+    def rowIdColumns(self) -> Cursor: ...
+    def rowVerColumns(self) -> Cursor: ...
+    def primaryKeys(self) -> Cursor: ...
+    def foreignKeys(self) -> Cursor: ...
+    def getTypeInfo(self) -> Cursor: ...
+    def procedures(self) -> Cursor: ...
+    def procedureColumns(self) -> Cursor: ...
+
+
+# a Row object represents a single database record, and behaves somewhat similar to a NamedTuple
+class Row:
+    cursor_description: Tuple[Tuple[str, _TV, int, int, int, int, bool]]
+
+
+# functions
+def dataSources() -> Dict[str, str]: ...
+def drivers() -> List[str]: ...
+
+def setDecimalSeparator(sep: str, /) -> None: ...
+def getDecimalSeparator() -> str: ...
+
+# https://www.python.org/dev/peps/pep-0249/#connect
+def connect(connstring: str,
+            /, *,  # positional-only parameters before, named-only after
+            autocommit: bool = False,
+            encoding: str = 'utf-16le',
+            ansi: bool = False,
+            readonly: bool = False,
+            timeout: int,
+            attrs_before: dict,
+            **kwargs) -> Connection: ...

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -64,7 +64,7 @@ static char module_doc[] =
     "  connections.  Note that connections and cursors may be used by different\n"
     "  threads, just not at the same time.\n"
     "\n"
-    "qmark\n"
+    "paramstyle\n"
     "  The string constant 'qmark' to indicate parameters are identified using\n"
     "  question marks.";
 

--- a/tests2/pgtests.py
+++ b/tests2/pgtests.py
@@ -536,7 +536,7 @@ class PGTestCase(unittest.TestCase):
 
         # using INFO message level because they are always sent to the client regardless of
         # client_min_messages: https://www.postgresql.org/docs/11/runtime-config-client.html
-        for message in ('hello world', 'A' * 30000):
+        for msg in ('hello world', 'ABCDEFGHIJ' * 400):
             self.cursor.execute("""
                 CREATE OR REPLACE PROCEDURE test_cursor_messages()
                 LANGUAGE plpgsql
@@ -545,16 +545,17 @@ class PGTestCase(unittest.TestCase):
                     RAISE INFO '{}' USING ERRCODE = '01000';
                 END;
                 $$;
-            """.format(message))
+            """.format(msg))
             self.cursor.execute("CALL test_cursor_messages();")
-            self.assertTrue(type(self.cursor.messages) is list)
-            self.assertEqual(len(self.cursor.messages), 1)
-            self.assertTrue(type(self.cursor.messages[0]) is tuple)
-            self.assertEqual(len(self.cursor.messages[0]), 2)
-            self.assertTrue(type(self.cursor.messages[0][0]) is unicode)
-            self.assertTrue(type(self.cursor.messages[0][1]) is unicode)
-            self.assertEqual('[01000] (-1)', self.cursor.messages[0][0])
-            self.assertTrue(self.cursor.messages[0][1].endswith(message))
+            messages = self.cursor.messages
+            self.assertTrue(type(messages) is list)
+            self.assertTrue(len(messages) > 0)
+            self.assertTrue(all(type(m) is tuple for m in messages))
+            self.assertTrue(all(len(m) == 2 for m in messages))
+            self.assertTrue(all(type(m[0]) is unicode for m in messages))
+            self.assertTrue(all(type(m[1]) is unicode for m in messages))
+            self.assertTrue(all(m[0] == '[01000] (-1)' for m in messages))
+            self.assertTrue(''.join(m[1] for m in messages).endswith(msg))
 
 
 def main():

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1492,15 +1492,16 @@ class SqlServerTestCase(unittest.TestCase):
         brand_new_cursor = self.cnxn.cursor()
         self.assertIsNone(brand_new_cursor.messages)
 
-        self.cursor.execute("PRINT 'hello world'")
-        self.assertTrue(type(self.cursor.messages) is list)
-        self.assertEqual(len(self.cursor.messages), 1)
-        self.assertTrue(type(self.cursor.messages[0]) is tuple)
-        self.assertEqual(len(self.cursor.messages[0]), 2)
-        self.assertTrue(type(self.cursor.messages[0][0]) is unicode)
-        self.assertTrue(type(self.cursor.messages[0][1]) is unicode)
-        self.assertEqual('[01000] (0)', self.cursor.messages[0][0])
-        self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
+        for message in ('hello world', 'A' * 30000):
+            self.cursor.execute("PRINT '{}'".format(message))
+            self.assertTrue(type(self.cursor.messages) is list)
+            self.assertEqual(len(self.cursor.messages), 1)
+            self.assertTrue(type(self.cursor.messages[0]) is tuple)
+            self.assertEqual(len(self.cursor.messages[0]), 2)
+            self.assertTrue(type(self.cursor.messages[0][0]) is unicode)
+            self.assertTrue(type(self.cursor.messages[0][1]) is unicode)
+            self.assertEqual('[01000] (0)', self.cursor.messages[0][0])
+            self.assertTrue(self.cursor.messages[0][1].endswith(message))
 
     def test_cursor_messages_with_stored_proc(self):
         """

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1492,16 +1492,19 @@ class SqlServerTestCase(unittest.TestCase):
         brand_new_cursor = self.cnxn.cursor()
         self.assertIsNone(brand_new_cursor.messages)
 
-        for message in ('hello world', 'A' * 30000):
-            self.cursor.execute("PRINT '{}'".format(message))
-            self.assertTrue(type(self.cursor.messages) is list)
-            self.assertEqual(len(self.cursor.messages), 1)
-            self.assertTrue(type(self.cursor.messages[0]) is tuple)
-            self.assertEqual(len(self.cursor.messages[0]), 2)
-            self.assertTrue(type(self.cursor.messages[0][0]) is unicode)
-            self.assertTrue(type(self.cursor.messages[0][1]) is unicode)
-            self.assertEqual('[01000] (0)', self.cursor.messages[0][0])
-            self.assertTrue(self.cursor.messages[0][1].endswith(message))
+        # SQL Server PRINT statements are never more than 8000 characters
+        # https://docs.microsoft.com/en-us/sql/t-sql/language-elements/print-transact-sql#remarks
+        for msg in ('hello world', 'ABCDEFGHIJ' * 800):
+            self.cursor.execute("PRINT '{}'".format(msg))
+            messages = self.cursor.messages
+            self.assertTrue(type(messages) is list)
+            self.assertEqual(len(messages), 1)
+            self.assertTrue(type(messages[0]) is tuple)
+            self.assertEqual(len(messages[0]), 2)
+            self.assertTrue(type(messages[0][0]) is unicode)
+            self.assertTrue(type(messages[0][1]) is unicode)
+            self.assertEqual('[01000] (0)', messages[0][0])
+            self.assertTrue(messages[0][1].endswith(msg))
 
     def test_cursor_messages_with_stored_proc(self):
         """

--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -642,24 +642,25 @@ class PGTestCase(unittest.TestCase):
 
         # using INFO message level because they are always sent to the client regardless of
         # client_min_messages: https://www.postgresql.org/docs/11/runtime-config-client.html
-        self.cursor.execute("""
-            CREATE OR REPLACE PROCEDURE test_cursor_messages()
-            LANGUAGE plpgsql
-            AS $$
-            BEGIN
-                RAISE INFO 'hello world' USING ERRCODE = '01000';
-            END;
-            $$;
-        """)
-        self.cursor.execute("CALL test_cursor_messages();")
-        self.assertTrue(type(self.cursor.messages) is list)
-        self.assertEqual(len(self.cursor.messages), 1)
-        self.assertTrue(type(self.cursor.messages[0]) is tuple)
-        self.assertEqual(len(self.cursor.messages[0]), 2)
-        self.assertTrue(type(self.cursor.messages[0][0]) is str)
-        self.assertTrue(type(self.cursor.messages[0][1]) is str)
-        self.assertEqual('[01000] (-1)', self.cursor.messages[0][0])
-        self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
+        for message in ('hello world', 'A' * 30000):
+            self.cursor.execute("""
+                CREATE OR REPLACE PROCEDURE test_cursor_messages()
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    RAISE INFO '{}' USING ERRCODE = '01000';
+                END;
+                $$;
+            """.format(message))
+            self.cursor.execute("CALL test_cursor_messages();")
+            self.assertTrue(type(self.cursor.messages) is list)
+            self.assertEqual(len(self.cursor.messages), 1)
+            self.assertTrue(type(self.cursor.messages[0]) is tuple)
+            self.assertEqual(len(self.cursor.messages[0]), 2)
+            self.assertTrue(type(self.cursor.messages[0][0]) is str)
+            self.assertTrue(type(self.cursor.messages[0][1]) is str)
+            self.assertEqual('[01000] (-1)', self.cursor.messages[0][0])
+            self.assertTrue(self.cursor.messages[0][1].endswith(message))
 
     def test_output_conversion(self):
         # Note the use of SQL_WVARCHAR, not SQL_VARCHAR.

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -1374,15 +1374,16 @@ class SqlServerTestCase(unittest.TestCase):
         brand_new_cursor = self.cnxn.cursor()
         self.assertIsNone(brand_new_cursor.messages)
 
-        self.cursor.execute("PRINT 'hello world'")
-        self.assertTrue(type(self.cursor.messages) is list)
-        self.assertEqual(len(self.cursor.messages), 1)
-        self.assertTrue(type(self.cursor.messages[0]) is tuple)
-        self.assertEqual(len(self.cursor.messages[0]), 2)
-        self.assertTrue(type(self.cursor.messages[0][0]) is str)
-        self.assertTrue(type(self.cursor.messages[0][1]) is str)
-        self.assertEqual('[01000] (0)', self.cursor.messages[0][0])
-        self.assertTrue(self.cursor.messages[0][1].endswith('hello world'))
+        for message in ('hello world', 'A' * 30000):
+            self.cursor.execute("PRINT '{}'".format(message))
+            self.assertTrue(type(self.cursor.messages) is list)
+            self.assertEqual(len(self.cursor.messages), 1)
+            self.assertTrue(type(self.cursor.messages[0]) is tuple)
+            self.assertEqual(len(self.cursor.messages[0]), 2)
+            self.assertTrue(type(self.cursor.messages[0][0]) is str)
+            self.assertTrue(type(self.cursor.messages[0][1]) is str)
+            self.assertEqual('[01000] (0)', self.cursor.messages[0][0])
+            self.assertTrue(self.cursor.messages[0][1].endswith(message))
 
     def test_cursor_messages_with_stored_proc(self):
         """


### PR DESCRIPTION
## What changes are proposed in this pull request?

When using Databricks with Simba Spark ODBC drivers, long error messages from Spark were occasionally truncated. We traced it down to fixed buffer sizes in GetDiagRecs and GetErrorFromHandle when calling SQLGetDiagRecW.
We now allocate the buffer on the heap instead of stack, and reallocate it to be bigger when needed.

https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdiagrec-function?view=sql-server-ver15 documents the SQLGetDiagRec function bufferLength as:
```
BufferLength
[Input] Length of the *MessageText buffer in characters. There is no maximum length of the diagnostic message text.
```
suggesting that the message length should not be limited by SQL_MAX_MESSAGE_LEN when using this API.

Also, changed GetSqlState to use SQLGetDiagField to retrieve the SQLState. That function seems to not be used though. (Used by HasSqlState, which is not used anywhere in the codebase.)

## How it was tested?

Now able to retrieve longer error messages using Simba Spark ODBC drivers and connecting to Databricks Spark Runtime.