### PR TITLE
Add support for Python 3.10, drop EOL 3.5

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -11,17 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 2.7
+          - python-version: "2.7"
             tests-dir: tests2
-          - python-version: 3.6
+          - python-version: "3.6"
             tests-dir: tests3
-          - python-version: 3.7
+          - python-version: "3.7"
             tests-dir: tests3
-          - python-version: 3.8
+          - python-version: "3.8"
             tests-dir: tests3
-          - python-version: 3.9
+          - python-version: "3.9"
             tests-dir: tests3
-          - python-version: 3.10-dev
+          - python-version: "3.10"
             tests-dir: tests3
 
     services:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -13,8 +13,6 @@ jobs:
         include:
           - python-version: 2.7
             tests-dir: tests2
-          - python-version: 3.5
-            tests-dir: tests3
           - python-version: 3.6
             tests-dir: tests3
           - python-version: 3.7

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -23,6 +23,8 @@ jobs:
             tests-dir: tests3
           - python-version: 3.9
             tests-dir: tests3
+          - python-version: 3.10-dev
+            tests-dir: tests3
 
     services:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,25 +60,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PYTHON_HOME: "C:\\Python27-x64"
 
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   PYTHON_HOME: "C:\\Python33"
-
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   PYTHON_HOME: "C:\\Python33-x64"
-
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   PYTHON_HOME: "C:\\Python34"
-
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   PYTHON_HOME: "C:\\Python34-x64"
-
     # Python 3.5+ need at least the Visual Studio 2015 image
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON_HOME: "C:\\Python35"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON_HOME: "C:\\Python35-x64"
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_HOME: "C:\\Python36"
@@ -97,6 +79,12 @@ environment:
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_HOME: "C:\\Python38-x64"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python39"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python39-x64"
 
 cache:
   - apvyr_cache -> appveyor\install.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,6 +86,12 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_HOME: "C:\\Python39-x64"
 
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python310"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python310-x64"
+
 cache:
   - apvyr_cache -> appveyor\install.ps1
 

--- a/appveyor/compile.cmd
+++ b/appveyor/compile.cmd
@@ -48,14 +48,10 @@ IF %PYTHON_MAJOR_VERSION% EQU 2 (
 ) ELSE (
     IF %PYTHON_MAJOR_VERSION% EQU 3 (
         SET WINDOWS_SDK_VERSION="v7.1"
-        IF %PYTHON_MINOR_VERSION% LEQ 4 (
-            SET SET_SDK_64=Y
-        ) ELSE (
-            SET SET_SDK_64=N
-            IF EXIST "%WIN_WDK%" (
-                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
-                REN "%WIN_WDK%" 0wdf
-            )
+        SET SET_SDK_64=N
+        IF EXIST "%WIN_WDK%" (
+            :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+            REN "%WIN_WDK%" 0wdf
         )
     ) ELSE (
         ECHO Unsupported Python version: "%PYTHON_MAJOR_VERSION%"

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,8 @@ def main():
                        'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',
+                       'Programming Language :: Python :: 3.9',
+                       'Programming Language :: Python :: 3.10',
                        'Topic :: Database',
                        ],
 

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,6 @@ def main():
                        'Programming Language :: Python :: 2',
                        'Programming Language :: Python :: 2.7',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.5',
                        'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,8 @@ def main():
 
         'license': 'MIT',
 
+        'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
+
         'classifiers': ['Development Status :: 5 - Production/Stable',
                        'Intended Audience :: Developers',
                        'Intended Audience :: System Administrators',


### PR DESCRIPTION
Fixes https://github.com/mkleehammer/pyodbc/issues/954.

Python 3.10.0 final is due for release in October:

* https://www.python.org/dev/peps/pep-0619/

The final release candidate is now out and the Python release team has issued a call to action for community members:

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.10 compatibilities during this phase. As always, report any issues to the Python bug tracker.

https://discuss.python.org/t/python-3-10-0rc2-is-now-available/10496?u=hugovk

So let's also test and add support for 3.10.

Drops support for EOL Python 3.5.