### PR TITLE
Replace deprecated SafeConfigParser with ConfigParser

### DIFF
--- a/tests3/testutils.py
+++ b/tests3/testutils.py
@@ -1,5 +1,5 @@
 import os, sys, platform
-from os.path import join, dirname, abspath, basename
+from os.path import join, dirname, abspath
 import unittest
 from distutils.util import get_platform
 
@@ -87,8 +87,8 @@ def load_setup_connection_string(section):
     If the file does not exist or if it exists but does not contain the connection string, None is returned.  If the
     file exists but cannot be parsed, an exception is raised.
     """
-    from os.path import exists, join, dirname, splitext, basename
-    from configparser import SafeConfigParser
+    from os.path import exists, join, dirname
+    from configparser import ConfigParser
 
     FILENAME = 'setup.cfg'
     KEY      = 'connection-string'
@@ -105,7 +105,7 @@ def load_setup_connection_string(section):
         path = parent
 
     try:
-        p = SafeConfigParser()
+        p = ConfigParser()
         p.read(fqn)
     except:
         raise SystemExit('Unable to parse %s: %s' % (path, sys.exc_info()[1]))


### PR DESCRIPTION
Replace deprecated `SafeConfigParser` with `ConfigParser`, deprecated since Python 3.2 and potentially being removed in Python 3.11 (due for release October 2022).

* https://bugs.python.org/issue45173

Remove some unused imports from the same file.