### PR TITLE
Build wheels with cibuildwheels on GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -191,3 +191,23 @@ jobs:
       run: |
         cd "$GITHUB_WORKSPACE"
         python "./${{ matrix.tests-dir }}/mysqltests.py" "DRIVER={MySQL ODBC 8.0 ANSI Driver};SERVER=localhost;UID=root;PWD=root;DATABASE=test;CHARSET=utf8mb4"
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.3
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,6 +1,6 @@
 name: Ubuntu build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   run_tests:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -206,7 +206,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.1.3
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-          CIBW_BEFORE_ALL_LINUX: apt-get -y install unixodbc-dev
+          CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get -y install unixodbc-dev
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -205,6 +205,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.3
         env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
           CIBW_BEFORE_ALL_LINUX: apt-get -y install unixodbc-dev
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -207,6 +207,7 @@ jobs:
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
           CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get -y install unixodbc-dev
+          CIBW_SKIP: "*-win32 *-manylinux_i686"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -206,6 +206,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.1.3
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
+          CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_24
           CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get -y install unixodbc-dev
           CIBW_SKIP: "*-win32 *-manylinux_i686"
 

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -204,9 +204,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.3
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
+        env:
+          CIBW_BEFORE_ALL_LINUX: apt-get -y install unixodbc-dev
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -206,9 +206,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.1.3
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-          CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_24
           CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get -y install unixodbc-dev
-          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          # disable 32-bit and pypy builds
+          CIBW_SKIP: "*-win32 *-manylinux_i686 pp*"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,7 @@ def get_version():
       1. If in a git repository, use the latest tag (git describe).
       2. If in an unzipped source directory (from setup.py sdist),
          read the version from the PKG-INFO file.
-      3. Use 4.0.0.0 and complain a lot.
+      3. Use 4.0.0.dev0 and complain a lot.
     """
     # My goal is to (1) provide accurate tags for official releases but (2) not have to manage tags for every test
     # release.
@@ -272,7 +272,7 @@ def get_version():
 
     if not numbers:
         _print('WARNING: Unable to determine version.  Using 4.0.0.0')
-        name, numbers = '4.0.0-unsupported', [4,0,0,0]
+        name, numbers = '4.0.0.dev0', [4,0,0,0]
 
     return name, numbers
 

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ def get_version():
 
     if not numbers:
         _print('WARNING: Unable to determine version.  Using 4.0.0.0')
-        name, numbers = '4.0.0.dev0', [4,0,0,0]
+        name, numbers = '4.0.dev0', [4,0,0,0]
 
     return name, numbers
 


### PR DESCRIPTION
Fixes #175
Ref #688
Closes #668
Closes #685
Fixes #441 and pretty much most issues that mention
` sql.h: No such file or directory`

This changes default version for checkout from `4.0.0-unsupported` to PEP 440 compliant `4.0.dev0`, which is needed by wheels. 

Needs PyPI keys for automated uploads.

Following the guide from https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions