### PR TITLE
ARM64 MacOS support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,12 +201,12 @@ def get_compiler_settings(version_str):
         settings['define_macros'].append(('MAC_OS_X_VERSION_10_7',))
 
         # Add directories for MacPorts and Homebrew.
-        dirs = ['/usr/local/include', '/opt/local/include', expanduser('~/homebrew/include')]
+        dirs = ['/usr/local/include', '/opt/local/include', '/opt/homebrew/include', expanduser('~/homebrew/include')]
         settings['include_dirs'].extend(dir for dir in dirs if isdir(dir))
 
         # unixODBC make/install places libodbc.dylib in /usr/local/lib/ by default
         # ( also OS/X since El Capitan prevents /usr/lib from being accessed )
-        settings['library_dirs'] = ['/usr/local/lib']
+        settings['library_dirs'] = ['/usr/local/lib', '/opt/homebrew/lib']
 
     else:
         # Other posix-like: Linux, Solaris, etc.


### PR DESCRIPTION
I closed the last PR because I thought these changes are not needed but it turned out that pip kept installing pyodbc from cache.
Tested this with `brew install microsoft/mssql-release/msodbcsql17`