### PR TITLE
Designate connection string argument type as optional

### DIFF
--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -440,7 +440,7 @@ def setDecimalSeparator(sep: str, /) -> None: ...
 def getDecimalSeparator() -> str: ...
 
 # https://www.python.org/dev/peps/pep-0249/#connect
-def connect(connstring: str,
+def connect(connstring: Optional[str] = None,
             /, *,  # only positional parameters before, only named parameters after
             autocommit: bool = False,
             encoding: str = 'utf-16le',


### PR DESCRIPTION
The signature for `pyodbc.connect()` designates the connection string as
required. However, the implementation in `src/pyodbcmodule.cpp`
`mod_connect` permits the string to be absent if there are no positional
arguments, relying instead on only keyword arguments.  The doc string in
`src/pyodbcmodule.cpp` `connect_doc` also confirms the string may be
optionally supplied.

This patch updates the type signature to reflect the implementation and
documentation.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>