### PR TITLE
Replace deprecated PyUnicode_FromUnicode(NULL, size) calls (#998)

### DIFF
--- a/src/row.cpp
+++ b/src/row.cpp
@@ -256,6 +256,7 @@ static int Row_setattro(PyObject* o, PyObject *name, PyObject* v)
 }
 
 
+#if PY_MAJOR_VERSION < 3
 static PyObject* Row_repr(PyObject* o)
 {
     Row* self = (Row*)o;
@@ -310,7 +311,74 @@ static PyObject* Row_repr(PyObject* o)
 
     return result;
 }
+#else // >= Python 3.3
+static PyObject* Row_repr(PyObject* o)
+{
+    Row* self = (Row*)o;
 
+    if (self->cValues == 0)
+        return PyUnicode_FromString("()");
+
+    Object pieces(PyTuple_New(self->cValues));
+    if (!pieces)
+        return 0;
+
+    Py_ssize_t length = 2 + (2 * (self->cValues-1)); // parens + ', ' separators
+    int result_kind = PyUnicode_1BYTE_KIND;
+
+    for (Py_ssize_t i = 0; i < self->cValues; i++)
+    {
+        PyObject* piece = PyObject_Repr(self->apValues[i]);
+        if (!piece)
+            return 0;
+
+        length += PyUnicode_GET_LENGTH(piece);
+        int kind = PyUnicode_KIND(piece);
+        if (result_kind < kind)
+            result_kind = kind;
+
+        PyTuple_SET_ITEM(pieces.Get(), i, piece);
+    }
+
+    if (self->cValues == 1)
+    {
+        // Need a trailing comma: (value,)
+        length += 2;
+    }
+    Py_UCS4 maxchar = 0x10ffff;
+    if (result_kind == PyUnicode_2BYTE_KIND)
+        maxchar = 0xffff;
+    else if (result_kind == PyUnicode_1BYTE_KIND)
+        maxchar = 0xff;
+    PyObject* result = PyUnicode_New(length, maxchar);
+    if (!result)
+        return 0;
+    Py_ssize_t offset = 0;
+    PyUnicode_WriteChar(result, offset++, (Py_UCS4)'(');
+    for (Py_ssize_t i = 0; i < self->cValues; i++)
+    {
+        PyObject* item = PyTuple_GET_ITEM(pieces.Get(), i);
+        Py_ssize_t count = PyUnicode_GET_LENGTH(item);
+        Py_ssize_t n = PyUnicode_CopyCharacters(result, offset, item, 0, count);
+        if (n < 0)
+            return 0;
+        offset += count;
+
+        if (i != self->cValues-1 || self->cValues == 1)
+        {
+            PyUnicode_WriteChar(result, offset++, (Py_UCS4)',');
+            PyUnicode_WriteChar(result, offset++, (Py_UCS4)' ');
+        }
+    }
+    PyUnicode_WriteChar(result, offset++, (Py_UCS4)')');
+    if (PyUnicode_READY(result) < 0)
+        return 0;
+
+    I(offset == length);
+
+    return result;
+}
+#endif
 
 static PyObject* Row_richcompare(PyObject* olhs, PyObject* orhs, int op)
 {

--- a/tests3/issue998.py
+++ b/tests3/issue998.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Verify that no warning is emitted for `PyUnicode_FromUnicode(NULL, size)`.
+
+See https://github.com/mkleehammer/pyodbc/issues/998.
+See also https://bugs.python.org/issue36346.
+"""
+
+import io
+import os
+import sys
+import unittest
+
+# pylint: disable-next=import-error
+from tests3.testutils import add_to_path, load_setup_connection_string
+
+add_to_path()
+import pyodbc  # pylint: disable=wrong-import-position
+
+KB = 1024
+MB = KB * 1024
+
+CONNECTION_STRING = None
+
+CONNECTION_STRING_ERROR_MESSAGE = (
+    "Please create tmp/setup.cfg file or "
+    "set a valid value to CONNECTION_STRING."
+)
+NO_ERROR = None
+
+
+class SQLPutDataUnicodeToBytesMemoryLeakTestCase(unittest.TestCase):
+    """Test case for issue998 bug fix."""
+
+    driver = pyodbc
+
+    @classmethod
+    def setUpClass(cls):
+        """Set the connection string."""
+
+        filename = os.path.splitext(os.path.basename(__file__))[0]
+        cls.connection_string = (
+            load_setup_connection_string(filename) or CONNECTION_STRING
+        )
+
+        if cls.connection_string:
+            return NO_ERROR
+        return ValueError(CONNECTION_STRING_ERROR_MESSAGE)
+
+    def test_use_correct_unicode_factory_function(self):
+        """Verify that the obsolete function call has been replaced."""
+
+        # Create a results set.
+        with pyodbc.connect(self.connection_string, autocommit=True) as cnxn:
+            cursor = cnxn.cursor()
+            cursor.execute("SELECT 1 AS a, 2 AS b")
+            rows = cursor.fetchall()
+
+        # Redirect stderr so we can detect the warning.
+        sys.stderr = redirected_stderr = io.StringIO()
+
+        # Convert the results object to a string.
+        self.assertGreater(len(str(rows)), 0)
+
+        # Restore stderr to the original stream.
+        sys.stderr = sys.__stderr__
+
+        # If the bug has been fixed, nothing will have been written to stderr.
+        self.assertEqual(len(redirected_stderr.getvalue()), 0)
+
+
+def main():
+    """Top-level driver for the test."""
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Current versions of Python write a deprecation warning message to `stderr`, which breaks CGI scripts running under web servers which fold `stderr` into `stdout`, and likely breaks other software. This change replaces the deprecated calls with `PyUnicode_New(size, maxchar)`. The accompanying code to populate the new objects has also been rewritten to use the new PyUnicode APIs.

I have included a unit test, but I assume others more familiar with the project will want to decide how to integrate it with the existing tests. I didn't fold the test in with any of the other sets, because the only sets in tests3 which were not DBMS-specific were for tests of the API, and this isn't a fix of API behavior (or rather, it's a fix of internals related to working with the Python APIs). The test fails without the fix and passes with it.

This is my second shot at a PR for this issue. My first attempt took the instructions in the deprecation warning and in the documentation for `PyUnicode_New()` at face value, but that wasn't sufficient, and the pipeline tests didn't all pass. So I dug deeper into the [documentation for all of the PyUnicode APIs](https://docs.python.org/3/c-api/unicode.html) and [PEP 393](https://www.python.org/dev/peps/pep-0393/) and did some more extensive rewriting of the two parts of `pyodbc` which were calling `PyUnicode_FromUnicode(NULL, size)`. Assuming this second attempt passes the pipeline tests, I would very much like some very close scrutiny of this patch. I am very confident that my experience with the Python C APIs is much less extensive than the seasoned maintainers for the project, and the documentation is thinner than I would have liked, and downright buggy in places (for example, the documentation [claims](http://ld2015.scusa.lsu.edu/python-3.3.2-docs-html/c-api/unicode.html#PyUnicode_CopyCharacters) that `PyUnicode_CopyCharacters()` returns `0` on success, but I figured out from digging through the Python API's own C code that the function actually returns the number of characters copied; note also the mixup in the argument names—the second `to` should be `from`).

```
int PyUnicode_CopyCharacters(PyObject *to, Py_ssize_t to_start, PyObject *to, Py_ssize_t from_start, Py_ssize_t how_many)
```

> Copy characters from one Unicode object into another. This function performs character conversion when necessary and falls back to memcpy() if possible. Returns -1 and sets an exception on error, otherwise returns 0.


Fixes #998