### PR TITLE
Fix for #1082 libraries in Linux wheels

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -197,18 +197,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.3
+        uses: pypa/cibuildwheel@v2.8.1
         env:
+          # use the Debian9-based image manylinux_2_24 (https://github.com/pypa/manylinux)
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
+          # need unixODBC on linux
           CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get -y install unixodbc-dev
-          # disable 32-bit and pypy builds
-          CIBW_SKIP: "*-win32 *-manylinux_i686 pp*"
+          # repairing the linux wheels adds old buggy versions of libraries to them, so don't (see issue 1081)
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
+          # for now, disable 32-bit, musllinux, and pypy builds
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_* pp*"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   run_tests:
-
+    name: Run tests on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -192,28 +192,56 @@ jobs:
         cd "$GITHUB_WORKSPACE"
         python "./${{ matrix.tests-dir }}/mysqltests.py" "DRIVER={MySQL ODBC 8.0 ANSI Driver};SERVER=localhost;UID=root;PWD=root;DATABASE=test;CHARSET=utf8mb4"
 
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - name: Upload builds
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: ./dist/*.gz
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        # https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job
+        os: [windows-2019, macos-11, ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.8.1
+        # https://cibuildwheel.readthedocs.io/en/stable/options/#options-summary
         env:
-          # use the Debian9-based image manylinux_2_24 (https://github.com/pypa/manylinux)
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-          # need unixODBC on linux
-          CIBW_BEFORE_ALL_LINUX: apt-get update && apt-get -y install unixodbc-dev
-          # repairing the linux wheels adds old buggy versions of libraries to them, so don't (see issue 1081)
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
-          # for now, disable 32-bit, musllinux, and pypy builds
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_* pp*"
+          # Windows - both 64-bit and 32-bit builds
+          CIBW_ARCHS_WINDOWS: "AMD64 x86"
 
-      - uses: actions/upload-artifact@v2
+          # macOS - both Intel and ARM builds; no bundled libraries
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+
+          # Linux - based on CentOS 7; glibc 64-bit builds only; no bundled libraries
+          # https://github.com/pypa/manylinux#docker-images
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_BEFORE_ALL_LINUX: yum -y install unixODBC-devel && odbcinst -j
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
+
+          # Build choices - disable musl Linux and PyPy builds
+          CIBW_SKIP: "*-musllinux_* pp*"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
         with:
+          name: wheels
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
It appears that the libodbc.so and libltdl.so libraries are added to the linux build wheels by the "repair" step in Github Actions.  This step adds any libraries it deems necessary to fulfil the "libraries" attribute in setup.py and also renames the linux build wheel files from "linux" to "manylinux".  As far as I can tell, that last rename is not strictly necessary, and can't be separated out, so I'm disabling that entire repair step.

Also, a few other notes:

- now using the latest version of cibuildwheel, 2.8.1
- for now, continue to use Debian-based linux images (rather than the latest AlmaLinux image)
- macos-10.15 will be removed on Aug 30, so update that
- don't build for musllinux, which seems to be problematic
- still not building 32-bit wheels, but we might want to re-visit that
- Debian9 installs unixODBC 2.3.4, which is old but I don't believe that is linked into the final wheels
- macOS wheels include the libodbc.2.dylib and libltdl.7.dylib libraries, which don't appear to be problematic, and libodbc seems to refer to unixODBC version 2.3.11 (the latest version, which is good)

Please do try out these new build wheels when you get a chance.
