### PR TITLE
Use argparse instead of optparse

### DIFF
--- a/tests3/accesstests.py
+++ b/tests3/accesstests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 usage="""\
-usage: %prog [options] filename
+%(prog)s [options] filename
 
 Unit tests for Microsoft Access
 
@@ -591,9 +591,9 @@ class AccessTestCase(unittest.TestCase):
 def main():
     from argparse import ArgumentParser
     parser = ArgumentParser(usage=usage)
-    parser.add_argument("-v", "--verbose", default=0, action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_argument("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_argument("-t", "--test", help="Run only the named test")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
     parser.add_argument('type', choices=['accdb', 'mdb'], help='Which type of file to test')
 
     args = parser.parse_args()

--- a/tests3/dbapitests.py
+++ b/tests3/dbapitests.py
@@ -7,13 +7,15 @@ def main():
     add_to_path()
     import pyodbc
 
-    from optparse import OptionParser
-    parser = OptionParser(usage="usage: %prog [options] connection_string")
-    parser.add_option("-v", "--verbose", action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage="%(prog)s [options] connection_string")
+    parser.add_argument("-v", "--verbose", action="count", help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("conn_str", nargs="*", help="database connection string")
 
-    (options, args) = parser.parse_args()
-    if len(args) > 1:
+    args = parser.parse_args()
+
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
     if not args:
@@ -23,7 +25,7 @@ def main():
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
     class test_pyodbc(dbapi20.DatabaseAPI20Test):
         driver = pyodbc
@@ -35,7 +37,7 @@ def main():
         def test_ExceptionsAsConnectionAttributes(self): pass
     
     suite = unittest.makeSuite(test_pyodbc, 'test')
-    testRunner = unittest.TextTestRunner(verbosity=(options.verbose > 1) and 9 or 0)
+    testRunner = unittest.TextTestRunner(verbosity=(args.verbose > 1) and 9 or 0)
     result = testRunner.run(suite)
 
     return result

--- a/tests3/exceltests.py
+++ b/tests3/exceltests.py
@@ -104,15 +104,16 @@ class ExcelTestCase(unittest.TestCase):
 
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser() #usage=usage)
-    parser.add_option("-v", "--verbose", action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser
+    parser = ArgumentParser() #usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("conn_str", nargs="*", help="connection string for Excel")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if args:
+    if args.conn_str:
         parser.error('no arguments expected')
     
     global CNXNSTRING
@@ -122,14 +123,14 @@ def main():
     assert os.path.exists(filename)
     CNXNSTRING = 'Driver={Microsoft Excel Driver (*.xls)};DBQ=%s;READONLY=FALSE' % filename
 
-    if options.verbose:
+    if args.verbose:
         cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
         print_library_info(cnxn)
         cnxn.close()
 
-    suite = load_tests(ExcelTestCase, options.test)
+    suite = load_tests(ExcelTestCase, args.test)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
     return result

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -2,7 +2,7 @@
 # -*- coding: latin-1 -*-
 
 usage = """\
-usage: %prog [options] connection_string
+%(prog)s [options] connection_string
 
 Unit tests for Informix DB.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
@@ -1221,34 +1221,35 @@ class InformixTestCase(unittest.TestCase):
 
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("conn_str", nargs="*", help="connection string for Informix")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if len(args) > 1:
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
-    if not args:
+    if not args.conn_str:
         connection_string = load_setup_connection_string('informixtests')
 
         if not connection_string:
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
-    if options.verbose:
+    if args.verbose:
         cnxn = pyodbc.connect(connection_string)
         print_library_info(cnxn)
         cnxn.close()
 
-    suite = load_tests(InformixTestCase, options.test, connection_string)
+    suite = load_tests(InformixTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
     return result

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 usage = """\
-usage: %prog [options] connection_string
+%(prog)s [options] connection_string
 
 Unit tests for MySQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
@@ -747,18 +747,19 @@ class MySqlTestCase(unittest.TestCase):
         self.assertEqual(result, v)
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("conn_str", nargs="*", help="connection string for MySQL")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if len(args) > 1:
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
-    if not args:
+    if not args.conn_str:
         filename = basename(sys.argv[0])
         assert filename.endswith('.py')
         connection_string = load_setup_connection_string(filename[:-3])
@@ -767,16 +768,16 @@ def main():
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
-    if options.verbose:
+    if args.verbose:
         cnxn = pyodbc.connect(connection_string)
         print_library_info(cnxn)
         cnxn.close()
 
-    suite = load_tests(MySqlTestCase, options.test, connection_string)
+    suite = load_tests(MySqlTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
     return result

--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 usage = """\
-usage: %prog [options] connection_string
+%(prog)s [options] connection_string
 
 Unit tests for PostgreSQL.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
@@ -707,46 +707,47 @@ class PGTestCase(unittest.TestCase):
         self.assertEqual(value, '123.45')
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage="usage: %prog [options] connection_string")
-    parser.add_option("-v", "--verbose", default=0, action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
-    parser.add_option('-a', '--ansi', help='ANSI only', default=False, action='store_true')
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("-a", "--ansi", help="ANSI only", default=False, action="store_true")
+    parser.add_argument("conn_str", nargs="*", help="connection string for PostgreSQL")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if len(args) > 1:
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
-    if not args:
+    if not args.conn_str:
         connection_string = load_setup_connection_string('pgtests')
 
         if not connection_string:
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
-    if options.verbose:
-        cnxn = pyodbc.connect(connection_string, ansi=options.ansi)
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string, ansi=args.ansi)
         print_library_info(cnxn)
         cnxn.close()
 
-    if options.test:
+    if args.test:
         # Run a single test
-        if not options.test.startswith('test_'):
-            options.test = 'test_%s' % (options.test)
+        if not args.test.startswith('test_'):
+            args.test = 'test_%s' % (args.test)
 
-        s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, options.test) ])
+        s = unittest.TestSuite([ PGTestCase(connection_string, args.ansi, args.test) ])
     else:
         # Run all tests in the class
 
         methods = [ m for m in dir(PGTestCase) if m.startswith('test_') ]
         methods.sort()
-        s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, m) for m in methods ])
+        s = unittest.TestSuite([ PGTestCase(connection_string, args.ansi, m) for m in methods ])
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(s)
 
     return result

--- a/tests3/sparktests.py
+++ b/tests3/sparktests.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 usage = """\
-usage: %prog [options] connection_string
+%(prog)s [options] connection_string
 
 Unit tests for Apache Spark. To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
@@ -489,46 +489,47 @@ class SparkTestCase(unittest.TestCase):
         self.assertEqual(result, v)
        
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage="usage: %prog [options] connection_string")
-    parser.add_option("-v", "--verbose", default=0, action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
-    parser.add_option('-a', '--ansi', help='ANSI only', default=False, action='store_true')
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("-a", "--ansi", help="ANSI only", default=False, action="store_true")
+    parser.add_argument("conn_str", nargs="*", help="connection string for Spark")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if len(args) > 1:
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
-    if not args:
+    if not args.conn_str:
         connection_string = load_setup_connection_string('sparktests')
 
         if not connection_string:
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
-    if options.verbose:
-        cnxn = pyodbc.connect(connection_string, ansi=options.ansi)
+    if args.verbose:
+        cnxn = pyodbc.connect(connection_string, ansi=args.ansi)
         print_library_info(cnxn)
         cnxn.close()
 
-    if options.test:
+    if args.test:
         # Run a single test
-        if not options.test.startswith('test_'):
-            options.test = 'test_%s' % (options.test)
+        if not args.test.startswith('test_'):
+            args.test = 'test_%s' % (args.test)
 
-        s = unittest.TestSuite([ SparkTestCase(connection_string, options.ansi, options.test) ])
+        s = unittest.TestSuite([ SparkTestCase(connection_string, args.ansi, args.test) ])
     else:
         # Run all tests in the class
 
         methods = [ m for m in dir(SparkTestCase) if m.startswith('test_') ]
         methods.sort()
-        s = unittest.TestSuite([ SparkTestCase(connection_string, options.ansi, m) for m in methods ])
+        s = unittest.TestSuite([ SparkTestCase(connection_string, args.ansi, m) for m in methods ])
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(s)
 
     return result

--- a/tests3/sqldwtests.py
+++ b/tests3/sqldwtests.py
@@ -4,7 +4,7 @@
 x = 1 # Getting an error if starting with usage for some reason.
 
 usage = """\
-usage: %prog [options] connection_string
+%(prog)s [options] connection_string
 
 Unit tests for Azure SQL DW.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
@@ -1398,34 +1398,35 @@ class SqlServerTestCase(unittest.TestCase):
         self.assertEqual(result, v)
         
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("conn_str", nargs="*", help="connection string for Azure SQL DW")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if len(args) > 1:
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
-    if not args:
+    if not args.conn_str:
         connection_string = load_setup_connection_string('sqldwtests')
 
         if not connection_string:
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
-    if options.verbose:
+    if args.verbose:
         cnxn = pyodbc.connect(connection_string)
         print_library_info(cnxn)
         cnxn.close()
 
-    suite = load_tests(SqlServerTestCase, options.test, connection_string)
+    suite = load_tests(SqlServerTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
     return result

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 usage = """\
-usage: %prog [options] connection_string
+%(prog)s [options] connection_string
 
 Unit tests for SQLite using the ODBC driver from http://www.ch-werner.de/sqliteodbc
 
@@ -648,34 +648,35 @@ class SqliteTestCase(unittest.TestCase):
 
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", default=0, action="count", help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("conn_str", nargs="*", help="connection string for sqlite")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if len(args) > 1:
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
-    if not args:
+    if not args.conn_str:
         connection_string = load_setup_connection_string('sqlitetests')
 
         if not connection_string:
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
-    if options.verbose:
+    if args.verbose:
         cnxn = pyodbc.connect(connection_string)
         print_library_info(cnxn)
         cnxn.close()
 
-    suite = load_tests(SqliteTestCase, options.test, connection_string)
+    suite = load_tests(SqliteTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
     return result

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -4,7 +4,7 @@
 x = 1 # Getting an error if starting with usage for some reason.
 
 usage = """\
-usage: %prog [options] connection_string
+%(prog)s [options] connection_string
 
 Unit tests for SQL Server.  To use, pass a connection string as the parameter.
 The tests will create and drop tables t1 and t2 as necessary.
@@ -1932,34 +1932,35 @@ class SqlServerTestCase(unittest.TestCase):
         self._test_tvp(True)
 
 def main():
-    from optparse import OptionParser
-    parser = OptionParser(usage=usage)
-    parser.add_option("-v", "--verbose", action="count", default=0, help="Increment test verbosity (can be used multiple times)")
-    parser.add_option("-d", "--debug", action="store_true", default=False, help="Print debugging items")
-    parser.add_option("-t", "--test", help="Run only the named test")
+    from argparse import ArgumentParser
+    parser = ArgumentParser(usage=usage)
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increment test verbosity (can be used multiple times)")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="print debugging items")
+    parser.add_argument("-t", "--test", help="run only the named test")
+    parser.add_argument("conn_str", nargs="*", help="connection string for SQL Server")
 
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
 
-    if len(args) > 1:
+    if len(args.conn_str) > 1:
         parser.error('Only one argument is allowed.  Do you need quotes around the connection string?')
 
-    if not args:
+    if not args.conn_str:
         connection_string = load_setup_connection_string('sqlservertests')
 
         if not connection_string:
             parser.print_help()
             raise SystemExit()
     else:
-        connection_string = args[0]
+        connection_string = args.conn_str[0]
 
-    if options.verbose:
+    if args.verbose:
         cnxn = pyodbc.connect(connection_string)
         print_library_info(cnxn)
         cnxn.close()
 
-    suite = load_tests(SqlServerTestCase, options.test, connection_string)
+    suite = load_tests(SqlServerTestCase, args.test, connection_string)
 
-    testRunner = unittest.TextTestRunner(verbosity=options.verbose)
+    testRunner = unittest.TextTestRunner(verbosity=args.verbose)
     result = testRunner.run(suite)
 
     return result


### PR DESCRIPTION
The standard library package `optparse` has been [deprecated](https://docs.python.org/3/library/optparse.html) since Python 3.2.  It will be removed in Python 3.12.  Hence, this PR replaces the use of `optparse` with `argparse` (but not in Python 2.7 code).