### PR TITLE
Fix memory leak with nvarchar(max) and fast_executemany

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -346,7 +346,6 @@ static int PyToCType(Cursor *cur, unsigned char **outbuf, PyObject *cell, ParamI
             {
                 // DAE
                 DAEParam *pParam = (DAEParam*)*outbuf;
-                Py_INCREF(cell);
                 pParam->cell = encoded.Detach();
                 pParam->maxlen = cur->cnxn->GetMaxLength(pi->ValueType);
                 *outbuf += sizeof(DAEParam);


### PR DESCRIPTION
Fixes: #1099