### PR TITLE
Build wheel files for Python 3.11

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -23,6 +23,8 @@ jobs:
             tests-dir: tests3
           - python-version: "3.10"
             tests-dir: tests3
+          - python-version: "3.11"
+            tests-dir: tests3
 
     services:
 
@@ -220,7 +222,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.11.2
         # https://cibuildwheel.readthedocs.io/en/stable/options/#options-summary
         env:
           # Windows - both 64-bit and 32-bit builds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,6 +92,12 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_HOME: "C:\\Python310-x64"
 
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python311"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python311-x64"
+
 cache:
   - apvyr_cache -> appveyor\install.ps1
 

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ def main():
                        'Programming Language :: Python :: 3.8',
                        'Programming Language :: Python :: 3.9',
                        'Programming Language :: Python :: 3.10',
+                       'Programming Language :: Python :: 3.11',
                        'Topic :: Database',
                        ],
 


### PR DESCRIPTION
Fixes: #1110

Update .github/workflows/ubuntu_build.yml to use
cibuildwheel v2.11.2

Add 3.11 references to appveyor.yml and setup.py