### PR TITLE
Run unit tests for Python 3.11 with Appveyor

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -167,8 +167,8 @@ jobs:
         cd "$GITHUB_WORKSPACE"
         echo "*** current python version"
         python -VV
-        echo "*** run setup.py"
-        python setup.py install
+        echo "*** pip install"
+        python -m pip install .
         echo "*** pip freeze"
         python -m pip freeze --all
         echo "*** pyodbc version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,12 +92,11 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_HOME: "C:\\Python310-x64"
 
-# TODO: enable these once Python 3.11 is supported on Windows
-#    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#      PYTHON_HOME: "C:\\Python311"
-#
-#    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#      PYTHON_HOME: "C:\\Python311-x64"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python311"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_HOME: "C:\\Python311-x64"
 
 cache:
   - apvyr_cache -> appveyor\install.ps1

--- a/appveyor/build_script.cmd
+++ b/appveyor/build_script.cmd
@@ -38,7 +38,7 @@ IF ERRORLEVEL 1 (
 
 ECHO.
 ECHO *** Installing pyodbc...
-"%PYTHON_HOME%\python" setup.py install
+"%PYTHON_HOME%\python" -m pip install .
 IF ERRORLEVEL 1 (
   ECHO *** ERROR: pyodbc install failed
   EXIT 1


### PR DESCRIPTION
Now that Appveyor has added Python 3.11 to their Windows image, we can run the unit tests against Python 3.11 on Windows.

Also, a tweak to the CICD pyodbc install commands to not use the soon-to-be-deprecated form ("python setup.py install").