### PR TITLE
Fix the package versions in the CI-generated wheels

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -225,8 +225,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         # https://cibuildwheel.readthedocs.io/en/stable/options/#options-summary
         env:
-          CIBW_BUILD_VERBOSITY: 1
-
           # Windows - both 64-bit and 32-bit builds
           CIBW_ARCHS_WINDOWS: "AMD64 x86"
 

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -230,14 +230,23 @@ jobs:
 
           # macOS - both Intel and ARM builds; no bundled libraries
           CIBW_ARCHS_MACOS: "x86_64 arm64"
+          # prevent the addition of unixODBC dylibs to the wheel by simply not calling the repair
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 
           # Linux - based on CentOS 7; glibc 64-bit builds only; no bundled libraries
           # https://github.com/pypa/manylinux#docker-images
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_LINUX: x86_64
+          # this installs unixODBC 2.3.1 which is quite old but it has the latest ABI so should be fine
           CIBW_BEFORE_ALL_LINUX: yum -y install unixODBC-devel
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --exclude libodbc.so.2 --exclude libltdl.so.7 --wheel-dir {dest_dir} {wheel}"
+          # the raw wheel filename is not PyPi compliant so the wheel must be repaired but
+          # suppress the addition of unixODBC libs to the wheel with --exclude's
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX:
+            auditwheel repair
+              --exclude libodbc.so.2
+              --exclude libltdl.so.7
+              --wheel-dir {dest_dir}
+              {wheel}
 
           # Build choices - disable musl Linux and PyPy builds
           CIBW_SKIP: "*-musllinux_* pp*"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -225,7 +225,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         # https://cibuildwheel.readthedocs.io/en/stable/options/#options-summary
         env:
-          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BUILD_VERBOSITY: 1
 
           # Windows - both 64-bit and 32-bit builds
           CIBW_ARCHS_WINDOWS: "AMD64 x86"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -236,8 +236,8 @@ jobs:
           # https://github.com/pypa/manylinux#docker-images
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_BEFORE_ALL_LINUX: yum -y install unixODBC-devel && odbcinst -j
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
+          CIBW_BEFORE_ALL_LINUX: yum -y install unixODBC-devel
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --exclude libodbc.so.2 --exclude libltdl.so.7 --wheel-dir {dest_dir} {wheel}"
 
           # Build choices - disable musl Linux and PyPy builds
           CIBW_SKIP: "*-musllinux_* pp*"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -225,6 +225,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         # https://cibuildwheel.readthedocs.io/en/stable/options/#options-summary
         env:
+          CIBW_BUILD_VERBOSITY: 2
+
           # Windows - both 64-bit and 32-bit builds
           CIBW_ARCHS_WINDOWS: "AMD64 x86"
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ x86/
 # Executables
 *.exe
 
+# Linters
+.flake8
+.pylintrc
+
 # Other
 pyodbc.conf
 tmp
@@ -54,4 +58,3 @@ tags
 # The Access unit tests copy empty.accdb and empty.mdb to these names and use them.
 test.accdb
 test.mdb
-

--- a/appveyor/test_script.cmd
+++ b/appveyor/test_script.cmd
@@ -9,6 +9,7 @@ ECHO *** Available ODBC Drivers:
 
 REM check if any testing should be done at all
 IF NOT "%APVYR_RUN_TESTS%" == "true" (
+  ECHO.
   ECHO *** Skipping all the unit tests
   GOTO :end
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -277,6 +277,10 @@ def get_version():
     # If we are in the CICD pipeline, use the VERSION, not least because there is no tagging
     # information available (Github Actions fetches the repo with the --no-tags and --depth=1 options).
 
+    _print([{e: os.getenv(e)} for e in ('CI', 'ci', 'GITHUB_ACTIONS')])
+    _print([{e: os.getenv(e)} for e in os.environ if e.startswith('CIBW')])
+    _print([{e: os.getenv(e)} for e in os.environ if e.startswith('GITHUB')])
+
     # All CI providers (Github Actions / Travis / CircleCI / AppVeyor / etc.) set CI to
     # "true" (or similar) but just in case, check for the provider directly as well.
     if os.getenv('CI', 'false').lower() in ('true', 't', 'yes', 'y', 'on', '1') or \

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ else:
 
 OFFICIAL_BUILD = 9999
 
+# This version identifier should refer to the NEXT release version, not the
+# current one.  After each release, the version should be incremented.
+VERSION = '4.0.35'
+
 
 def _print(s):
     # Python 2/3 compatibility
@@ -269,6 +273,15 @@ def get_version():
 
     name    = None              # branch/feature name.  Should be None for official builds.
     numbers = None              # The 4 integers that make up the version.
+
+    # If we are in the CICD pipeline, use the VERSION, not least because there is no tagging
+    # information available (Github Actions fetches the repo with the --no-tags and --depth=1 options).
+
+    # All CICD engines (Github Actions / Travis / CircleCI / AppVeyor) set CI to "True"/"true"
+    if os.getenv('CI', 'false').lower() == 'true':
+        name = VERSION
+        numbers = [int(p) for p in VERSION.split('.')]
+        return name, numbers
 
     # If this is a source release the version will have already been assigned and be in the PKG-INFO file.
 

--- a/setup.py
+++ b/setup.py
@@ -277,8 +277,11 @@ def get_version():
     # If we are in the CICD pipeline, use the VERSION, not least because there is no tagging
     # information available (Github Actions fetches the repo with the --no-tags and --depth=1 options).
 
-    # All CICD engines (Github Actions / Travis / CircleCI / AppVeyor) set CI to "True"/"true"
-    if os.getenv('CI', 'false').lower() == 'true':
+    # All CI providers (Github Actions / Travis / CircleCI / AppVeyor / etc.) set CI to
+    # "true" (or similar) but just in case, check for the provider directly as well.
+    if os.getenv('CI', 'false').lower() in ('true', 't', 'yes', 'y', 'on', '1') or \
+       'GITHUB_ACTIONS' in os.environ or \
+       'APPVEYOR' in os.environ:
         name = VERSION
         numbers = [int(p) for p in VERSION.split('.')]
         return name, numbers

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
 
 OFFICIAL_BUILD = 9999
 
-# This version identifier should refer to the NEXT release version, not the
+# This version identifier should refer to the NEXT release, not the
 # current one.  After each release, the version should be incremented.
 VERSION = '4.0.35'
 
@@ -274,10 +274,10 @@ def get_version():
     name    = None              # branch/feature name.  Should be None for official builds.
     numbers = None              # The 4 integers that make up the version.
 
-    # If we are in the CICD pipeline, use the VERSION, not least because there is no tagging
-    # information available (Github Actions fetches the repo with the options --no-tags and --depth=1).
+    # If we are in the CICD pipeline, use the VERSION.  There is no tagging information available
+    # because Github Actions fetches the repo with the options --no-tags and --depth=1.
 
-    # CI providers (Github Actions / Travis / CircleCI / AppVeyor / etc.) usually set CI to "true", but
+    # CI providers (Github Actions / Travis / CircleCI / AppVeyor / etc.) typically set CI to "true", but
     # in cibuildwheel linux containers, the usual CI env vars are not available, only CIBUILDWHEEL.
     if os.getenv('CI', 'false').lower() == 'true' or 'CIBUILDWHEEL' in os.environ:
         name = VERSION

--- a/setup.py
+++ b/setup.py
@@ -275,16 +275,11 @@ def get_version():
     numbers = None              # The 4 integers that make up the version.
 
     # If we are in the CICD pipeline, use the VERSION, not least because there is no tagging
-    # information available (Github Actions fetches the repo with the --no-tags and --depth=1 options).
+    # information available (Github Actions fetches the repo with the options --no-tags and --depth=1).
 
-    for e in os.environ:
-        _print(str({e: os.getenv(e)}))
-
-    # All CI providers (Github Actions / Travis / CircleCI / AppVeyor / etc.) set CI to
-    # "true" (or similar) but just in case, check for the provider directly as well.
-    if os.getenv('CI', 'false').lower() in ('true', 't', 'yes', 'y', 'on', '1') or \
-       'GITHUB_ACTIONS' in os.environ or \
-       'APPVEYOR' in os.environ:
+    # CI providers (Github Actions / Travis / CircleCI / AppVeyor / etc.) usually set CI to "true", but
+    # in cibuildwheel linux containers, the usual CI env vars are not available, only CIBUILDWHEEL.
+    if os.getenv('CI', 'false').lower() == 'true' or 'CIBUILDWHEEL' in os.environ:
         name = VERSION
         numbers = [int(p) for p in VERSION.split('.')]
         return name, numbers

--- a/setup.py
+++ b/setup.py
@@ -277,9 +277,8 @@ def get_version():
     # If we are in the CICD pipeline, use the VERSION, not least because there is no tagging
     # information available (Github Actions fetches the repo with the --no-tags and --depth=1 options).
 
-    _print([{e: os.getenv(e)} for e in ('CI', 'ci', 'GITHUB_ACTIONS')])
-    _print([{e: os.getenv(e)} for e in os.environ if e.startswith('CIBW')])
-    _print([{e: os.getenv(e)} for e in os.environ if e.startswith('GITHUB')])
+    for e in os.environ:
+        _print(str({e: os.getenv(e)}))
 
     # All CI providers (Github Actions / Travis / CircleCI / AppVeyor / etc.) set CI to
     # "true" (or similar) but just in case, check for the provider directly as well.


### PR DESCRIPTION
The wheels generated by `cibuildwheel` in our CI pipeline currently have the wrong pyodbc package version id.s  For example, the file "pyodbc-**4.0.dev0**-cp310-cp310-win_amd64.whl".  "4.0.dev0" is incorrect and should be something like "4.0.35".  The wheels are given the id "4.0.dev0" because `setup.py` is unable to find any tags in the available git repo.  When building pyodbc locally on laptops, `setup.py` usually figures out the version from the git tags in the local repo.  `setup.py` is unable to figure this out in the CI pipeline because Github Actions does not include the tags when it fetches the repo.  It uses a command similar to:

```
/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +cafa37e846e09b36ebf821ac69b6f7d35f423baa:refs/remotes/origin/fix-labels-on-cicd-wheels
```

Note the options `--no-tags` and `--depth=1`.

To get around this, I have introduced a constant to `setup.py` called VERSION, currently of value "4.0.35".  When `setup.py` is called within the CI pipelines, `setup.py` will detect this and use the VERSION constant.  This constant will naturally have to be manually maintained but that shouldn't be too onerous.

Whilst here, I have added a basic `pyproject.toml` file to help pyodbc be more PEP517-compliant.  We should probably make more use of `pyproject.toml` in the future, transferring the static elements of `setup.py` into it at some point.

Also, a tweak to `.gitignore`.