### PR TITLE
Test with Windows 18 ODBC driver for SQL Server

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -74,6 +74,13 @@ jobs:
         echo "*** cat /etc/odbc.ini"
         cat /etc/odbc.ini
 
+    - name: Install ODBC driver for SQL Server
+      run: |
+        echo "*** apt-get install the driver"
+        sudo ACCEPT_EULA=Y apt-get install --yes msodbcsql18
+        echo '*** ls -l /usr/lib/x86_64-linux-gnu/odbc'
+        ls -l /opt/microsoft/msodbcsql18/lib64 || true
+
     - name: Install ODBC driver for PostgreSQL
       run: |
         echo "*** apt-get install the driver"
@@ -115,6 +122,8 @@ jobs:
         cat /etc/odbc.ini
         echo '*** ls -l /opt/microsoft/msodbcsql17/lib64'
         ls -l /opt/microsoft/msodbcsql17/lib64 || true
+        echo '*** ls -l /opt/microsoft/msodbcsql18/lib64'
+        ls -l /opt/microsoft/msodbcsql18/lib64 || true
         echo '*** ls -l /usr/lib/x86_64-linux-gnu/odbc'
         ls -l /usr/lib/x86_64-linux-gnu/odbc || true
 
@@ -173,6 +182,8 @@ jobs:
         python -m pip freeze --all
         echo "*** pyodbc version"
         python -c "import pyodbc; print(pyodbc.version)"
+        echo "*** pyodbc drivers"
+        python -c "import pyodbc; print('\n'.join(sorted(pyodbc.drivers())))"
 
     - name: Run SQL Server 2017 tests
       run: |
@@ -182,7 +193,7 @@ jobs:
     - name: Run SQL Server 2019 tests
       run: |
         cd "$GITHUB_WORKSPACE"
-        python "./${{ matrix.tests-dir }}/sqlservertests.py" "DRIVER={ODBC Driver 17 for SQL Server};SERVER=localhost,1402;UID=sa;PWD=StrongPassword2019;DATABASE=test"
+        python "./${{ matrix.tests-dir }}/sqlservertests.py" "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1402;UID=sa;PWD=StrongPassword2019;DATABASE=test;Encrypt=Optional"
 
     - name: Run PostgreSQL tests
       run: |

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -157,8 +157,15 @@ CheckAndInstallMsiFromUrl `
 CheckAndInstallMsiFromUrl `
     -driver_name "ODBC Driver 17 for SQL Server" `
     -driver_bitness "64-bit" `
-    -driver_url "https://download.microsoft.com/download/E/6/B/E6BFDC7A-5BCD-4C51-9912-635646DA801E/en-US/17.5.2.1/x64/msodbcsql.msi" `
-    -msifile_path "$cache_dir\msodbcsql_17.5.1.1_x64.msi" `
+    -driver_url "https://download.microsoft.com/download/6/f/f/6ffefc73-39ab-4cc0-bb7c-4093d64c2669/en-US/17.10.1.1/x64/msodbcsql.msi" `
+    -msifile_path "$cache_dir\msodbcsql_17.10.1.1_x64.msi" `
+    -msiexec_paras @("IACCEPTMSODBCSQLLICENSETERMS=YES", "ADDLOCAL=ALL");
+
+CheckAndInstallMsiFromUrl `
+    -driver_name "ODBC Driver 18 for SQL Server" `
+    -driver_bitness "64-bit" `
+    -driver_url "https://download.microsoft.com/download/9/1/f/91fc3f67-34bd-44c7-9431-be5919dc8377/en-US/18.1.2.1/x64/msodbcsql.msi" `
+    -msifile_path "$cache_dir\msodbcsql_18.1.2.1_x64.msi" `
     -msiexec_paras @("IACCEPTMSODBCSQLLICENSETERMS=YES", "ADDLOCAL=ALL");
 
 # some drivers must be installed in alignment with Python's bitness

--- a/appveyor/test_script.cmd
+++ b/appveyor/test_script.cmd
@@ -139,6 +139,25 @@ IF ERRORLEVEL 1 (
   ECHO *** ERROR: Could not connect using the connection string:
   ECHO "%CONN_STR%"
   SET OVERALL_RESULT=1
+  GOTO :mssql6
+)
+SET PYTHON_ARGS="%CONN_STR:"=\"%"
+IF "%APVYR_VERBOSE%" == "true" (
+  SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
+)
+"%PYTHON_HOME%\python" "%TESTS_DIR%\sqlservertests.py" %PYTHON_ARGS%
+IF ERRORLEVEL 1 SET OVERALL_RESULT=1
+
+:mssql6
+SET DRIVER={ODBC Driver 18 for SQL Server}
+SET CONN_STR=Driver=%DRIVER%;Server=%MSSQL_INSTANCE%;Database=test_db;UID=sa;PWD=Password12!;Encrypt=Optional;
+ECHO.
+ECHO *** Run tests using driver: "%DRIVER%"
+"%PYTHON_HOME%\python" appveyor\test_connect.py "%CONN_STR%"
+IF ERRORLEVEL 1 (
+  ECHO *** ERROR: Could not connect using the connection string:
+  ECHO "%CONN_STR%"
+  SET OVERALL_RESULT=1
   GOTO :postgresql
 )
 SET PYTHON_ARGS="%CONN_STR:"=\"%"


### PR DESCRIPTION
Turns out, the build tests aren't testing against the latest Windows ODBC driver for SQL Server ([version 18](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16)).  This PR addresses that.  Also, when testing on Windows, use a more recent version of the version 17 driver.