### PR TITLE
Add docstrings and more to pyodbc.pyi

### DIFF
--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -1,5 +1,13 @@
 from __future__ import annotations
-from typing import Any, Callable, Dict, Generator, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any, Callable, Dict, Final, Generator, Iterable, Iterator,
+    List, Optional, Sequence, Tuple, TypeAlias, Union,
+)
+
+# ref: https://peps.python.org/pep-0249/#description
+FieldDescription: TypeAlias = Tuple[str, Any, int, int, int, int, bool]
+RowDescription: TypeAlias = Tuple[FieldDescription]
+
 
 
 # SQLSetConnectAttr attributes
@@ -299,15 +307,17 @@ SQLWCHAR_SIZE: int
 
 # module attributes
 # https://www.python.org/dev/peps/pep-0249/#globals
+
 # read-only
-version: str  # not pep-0249
-apilevel: str
-threadsafety: int
-paramstyle: str
-# read-write
-pooling: bool
-lowercase: bool
-native_uuid: bool
+apilevel: Final[str] = '2.0'
+paramstyle: Final[str] = 'qmark'
+threadsafety: Final[int] = 1
+version: Final[str]  # not pep-0249
+
+# read-write (not pep-0249)
+lowercase: bool = False
+native_uuid: bool = False
+pooling: bool = True
 
 
 # exceptions
@@ -324,58 +334,256 @@ class ProgrammingError(DatabaseError): ...
 class NotSupportedError(DatabaseError): ...
 
 
-# an ODBC connection to the database, for managing database transactions and creating cursors
-# https://www.python.org/dev/peps/pep-0249/#connection-objects
 class Connection:
+    """The ODBC connection class representing an ODBC connection to a database, for
+    managing database transactions and creating cursors.
+    https://www.python.org/dev/peps/pep-0249/#connection-objects
 
-    # read-write attributes
-    autocommit: bool
-    maxwrite: int
-    timeout: int
+    This class should not be instantiated directly, instead call pyodbc.connect() to
+    create a Connection object.
+    """
 
-    # read-only attributes
-    searchescape: str
+    @property
+    def autocommit(self) -> bool:
+        """Whether the database automatically executes a commit after every successful transaction.
+        Default is False.
+        """
+        ...
+
+    @autocommit.setter
+    def autocommit(self, value: bool) -> None:
+        ...
+
+    @property
+    def maxwrite(self) -> int:
+        """The maximum bytes to write before using SQLPutData, default is zero for no maximum."""
+        ...
+
+    @maxwrite.setter
+    def maxwrite(self, value: int) -> None:
+        ...
+
+    @property
+    def searchescape(self) -> str:
+        """The character for escaping search pattern characters like "%" and "_".
+        This is typically the backslash character but can be driver-specific."""
+        ...
+
+    @property
+    def timeout(self) -> int:
+        """The timeout in seconds for SQL queries, use zero (the default) for no timeout limit."""
+        ...
+
+    @timeout.setter
+    def timeout(self, value: int) -> None:
+        ...
+
 
     # implemented dunder methods
     def __enter__(self) -> Connection: ...
     def __exit__(self, exc_type, exc_value, traceback) -> None: ...
 
-    # define text encoding for data, metadata, etc.
-    def setencoding(self, encoding: str, ctype: Optional[int]) -> None: ...
-    def setdecoding(self, encoding: str, ctype: Optional[int]) -> None: ...
 
-    # connection attributes
-    def getinfo(self, infotype: int, /) -> Any: ...
-    def set_attr(self, attr_id: int, value: int, /) -> None: ...
+    # functions for defining the text encoding used for data, metadata, sql, parameters, etc.
 
-    # handle non-standard database data types
-    def add_output_converter(self, sqltype: int, new_converter: Callable, /) -> None: ...
-    def get_output_converter(self, sqltype: int, /) -> Optional[Callable]: ...
-    def remove_output_converter(self, sqltype: int, /) -> None: ...
-    def clear_output_converters(self) -> None: ...
+    def setencoding(self,
+                    encoding: Optional[str] = None,
+                    ctype: Optional[int] = None) -> None:
+        """Set the text encoding for SQL statements and textual parameters sent to the database.
 
-    # query functions (in rough order of use)
-    def cursor(self) -> Cursor: ...
-    def execute(self, sql: str, *params: Any) -> Cursor: ...
-    def commit(self) -> None: ...
-    def rollback(self) -> None: ...
-    def close(self) -> None: ...
+        Args:
+            encoding: Text encoding codec, e.g. "utf-8".
+            ctype: The C data type when passing data - either pyodbc.SQL_CHAR or pyodbc.SQL_WCHAR.  More
+                relevant for Python 2.7.
+        """
+        ...
+
+    def setdecoding(self,
+                    sqltype: int,
+                    encoding: Optional[str] = None,
+                    ctype: Optional[int] = None) -> None:
+        """Set the text decoding used when reading SQL_CHAR or SQL_WCHAR data from the database.
+
+        Args:
+            sqltype: pyodbc.SQL_CHAR, pyodbc.SQL_WCHAR, or pyodbc.SQL_WMETADATA.
+            encoding: Text encoding codec, e.g. "utf-8".
+            ctype: The C data type to request from SQLGetData - either pyodbc.SQL_CHAR or
+                pyodbc.SQL_WCHAR.  More relevant for Python 2.7.
+        """
+        ...
 
 
-# cursors are vehicles for executing SQL statements and returning their results
-# https://www.python.org/dev/peps/pep-0249/#cursor-objects
+    # functions for getting/setting connection attributes
+
+    def getinfo(self, infotype: int, /) -> Any:
+        """Retrieve general information about the driver and the data source, via SQLGetInfo.
+
+        Args:
+            infotype: Id of the information to retrieve.
+
+        Returns:
+            The value of the requested information.
+        """
+        ...
+
+    def set_attr(self, attr_id: int, value: int, /) -> None:
+        """Set an attribute on the connection, via SQLSetConnectAttr.
+
+        Args:
+            attr_id: Id for the attribute, as defined by ODBC or the driver.
+            value: The value of the attribute.
+        """
+        ...
+
+
+    # functions to handle non-standard database data types
+
+    def add_output_converter(self, sqltype: int, func: Optional[Callable], /) -> None:
+        """Register an output converter function that will be called whenever a value
+        with the given SQL type is read from the database.  See the Wiki for details:
+        https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function
+
+        Args:
+            sqltype: The SQL type for the values to convert.
+            func: The converter function.
+        """
+        ...
+
+    def get_output_converter(self, sqltype: int, /) -> Optional[Callable]:
+        """Retrieve the (previously registered) converter function for the SQL type.
+
+        Args:
+            sqltype: The SQL type.
+
+        Returns:
+            The converter function if it exists, None otherwise.
+        """
+        ...
+
+    def remove_output_converter(self, sqltype: int, /) -> None:
+        """Delete a previously registered output converter function.
+
+        Args:
+            sqltype: The SQL type.
+        """
+        ...
+
+    def clear_output_converters(self) -> None:
+        """Delete all previously registered converter functions."""
+        ...
+
+
+    # functions for managing database transactions (in typical order of use)
+
+    def cursor(self) -> Cursor:
+        """Create a new cursor on the connection.
+
+        Returns:
+            A new cursor.
+        """
+        ...
+
+    def execute(self, sql: str, *params: Any) -> Cursor:
+        """A convenience function for running queries directly from a Connection object.
+        Creates a new cursor, runs the SQL query, and returns the new cursor.
+
+        Args:
+            sql: The SQL query.
+            *params: Any parameter values for the SQL query.
+
+        Returns:
+            A new cursor.
+        """
+        ...
+
+    def commit(self) -> None:
+        """Commit all SQL statements executed on the connection since the last commit/rollback."""
+        ...
+
+    def rollback(self) -> None:
+        """Rollback all SQL statements executed on the connection since the last commit/rollback."""
+        ...
+
+    def close(self) -> None:
+        """Close the connection.  Any uncommitted SQL statements will be rolled back."""
+        ...
+
+
 class Cursor:
+    """The class representing database cursors.  Cursors are vehicles for executing SQL
+    statements and returning their results.
+    https://www.python.org/dev/peps/pep-0249/#cursor-objects
 
-    # read-write attributes
-    arraysize: int
-    fast_executemany: bool
-    noscan: bool
+    This class should not be instantiated directly, instead call cursor() from a Connection
+    object to create a Cursor object.
+    """
 
-    # read-only attributes
-    description: Tuple[Tuple[str, Any, int, int, int, int, bool]]
-    messages: Optional[List[Tuple[str, Union[str, bytes]]]]
-    rowcount: int
-    connection: Connection
+    @property
+    def arraysize(self) -> int:
+        """The number of rows at a time to fetch with fetchmany(), default is 1."""
+        ...
+
+    @arraysize.setter
+    def arraysize(self, value: int) -> None:
+        ...
+
+    @property
+    def connection(self) -> Connection:
+        """The parent Connection object for the cursor."""
+        ...
+
+    @property
+    def description(self) -> RowDescription:
+        """The metadata for the columns returned in the last SQL SELECT statement, in
+        the form of a list of tuples.  Each tuple contains seven fields:
+
+        0. name of the column (or column alias)
+        1. type code, the Python-equivalent class of the column, e.g. str for VARCHAR
+        2. display size (pyodbc does not set this value)
+        3. internal size (in bytes)
+        4. precision
+        5. scale
+        6. nullable (True/False)
+        """
+        ...
+
+    @property
+    def fast_executemany(self) -> bool:
+        """When this cursor property is False (the default), calls to executemany() do
+        nothing more than iterate over the provided list of parameters and calls execute()
+        on each set of parameters.  This is typically slow.  When fast_executemany is
+        True, the parameters are sent to the database in one bundle (with the SQL).  This
+        is usually much faster, but there are limitations.  Check the Wiki for details.
+        https://github.com/mkleehammer/pyodbc/wiki/Cursor#executemanysql-params-with-fast_executemanytrue
+        """
+        ...
+
+    @fast_executemany.setter
+    def fast_executemany(self, value: bool) -> None:
+        ...
+
+    @property
+    def messages(self) -> Optional[List[Tuple[str, Union[str, bytes]]]]:
+        """Any descriptive messages returned by the last call to execute(), e.g. PRINT
+        statements, or None."""
+        ...
+
+    @property
+    def noscan(self) -> bool:
+        """Whether the driver should scan SQL strings for escape sequences, default is True."""
+        ...
+
+    @noscan.setter
+    def noscan(self, value: bool) -> None:
+        ...
+
+    @property
+    def rowcount(self) -> int:
+        """The number of rows modified by the last SQL statement.  Has the value of -1
+        if the number of rows is unknown or unavailable.
+        """
+        ...
+
 
     # implemented dunder methods
     def __enter__(self) -> Cursor: ...
@@ -383,38 +591,330 @@ class Cursor:
     def __iter__(self, /) -> Cursor: ...
     def __next__(self, /) -> Row: ...
 
-    # query functions (in rough order of use)
-    def setinputsizes(self, sizes: List[Tuple[int, int, int]], /) -> None: ...
-    def setoutputsize(self) -> None: ...
-    def execute(self, sql: str, *params: Any) -> Cursor: ...
-    def executemany(self, sql: str, params: Union[Sequence, Iterator, Generator], /) -> None: ...
-    def fetchone(self) -> Row: ...
-    def fetchmany(self, size: int, /) -> List[Row]: ...
-    def fetchall(self) -> List[Row]: ...
-    def fetchval(self) -> Any: ...
-    def skip(self, count: int, /) -> None: ...
-    def nextset(self) -> bool: ...
-    def commit(self) -> None: ...
-    def rollback(self) -> None: ...
-    def cancel(self) -> None: ...
-    def close(self) -> None: ...
 
-    # metadata functions
-    def tables(self) -> Cursor: ...
-    def columns(self) -> Cursor: ...
-    def statistics(self) -> Cursor: ...
-    def rowIdColumns(self) -> Cursor: ...
-    def rowVerColumns(self) -> Cursor: ...
-    def primaryKeys(self) -> Cursor: ...
-    def foreignKeys(self) -> Cursor: ...
-    def getTypeInfo(self) -> Cursor: ...
-    def procedures(self) -> Cursor: ...
-    def procedureColumns(self) -> Cursor: ...
+    # functions for running SQL queries (in rough order of use)
+
+    def setinputsizes(self, sizes: Optional[Iterable[Tuple[int, int, int]]], /) -> None:
+        """Explicitly declare the types and sizes of the parameters in a query.  Set
+        to None to clear any previously registered input sizes.
+
+        Args:
+            sizes: A list of tuples, one tuple for each query parameter, where each
+                tuple contains:
+
+                    1. the column datatype
+                    2. the column size (char length or decimal precision)
+                    3. the decimal scale.
+
+                For example: [(pyodbc.SQL_WVARCHAR, 50, 0), (pyodbc.SQL_DECIMAL, 18, 4)]
+        """
+        ...
+
+    def setoutputsize(self) -> None:
+        """Not supported."""
+        ...
+
+    def execute(self, sql: str, *params: Any) -> Cursor:
+        """Run a SQL query and return the cursor.
+
+        Args:
+            sql: The SQL query.
+            *params: Any parameters for the SQL query, as positional arguments or a single iterable.
+
+        Returns:
+            The cursor, so that calls on the cursor can be chained.
+        """
+        ...
+
+    def executemany(self, sql: str, params: Union[Sequence, Iterator, Generator], /) -> None:
+        """Run the SQL query against an iterable of parameters.  The behavior of this
+        function depends heavily on the setting of the fast_executemany cursor property.
+        See the Wiki for details.
+        https://github.com/mkleehammer/pyodbc/wiki/Cursor#executemanysql-params-with-fast_executemanyfalse-the-default
+        https://github.com/mkleehammer/pyodbc/wiki/Cursor#executemanysql-params-with-fast_executemanytrue
+
+        Args:
+            sql: The SQL query.
+            *params: Any parameters for the SQL query, as an iterable of parameter sets.
+        """
+        ...
+
+    def fetchone(self) -> Optional[Row]:
+        """Retrieve the next row in the current result set for the query.
+
+        Returns:
+            A row of results, or None if there is no more data to return.
+        """
+        ...
+
+    def fetchmany(self, size: int, /) -> List[Row]:
+        """Retrieve the next rows in the current result set for the query, as a list.
+
+        Args:
+            size: The number of rows to return.
+
+        Returns:
+            A list of rows, or an empty list if there is no more data to return.
+        """
+        ...
+
+    def fetchall(self) -> List[Row]:
+        """Retrieve all the remaining rows in the current result set for the query, as a list.
+
+        Returns:
+            A list of rows, or an empty list if there is no more data to return.
+        """
+        ...
+
+    def fetchval(self) -> Any:
+        """A convenience function for returning the first column of the first row from
+        the query.
+
+        Returns:
+            The value in the first column of the first row, or None if there is no data.
+        """
+        ...
+
+    def skip(self, count: int, /) -> None:
+        """Skip over rows in the current result set of a query.
+
+        Args:
+            count: The number of rows to skip.
+        """
+        ...
+
+    def nextset(self) -> bool:
+        """Switch to the next result set in the SQL query (e.g. if there are
+        multiple SELECT statements in the SQL script).
+
+        Returns:
+            True if there are more result sets, False otherwise.
+        """
+        ...
+
+    def commit(self) -> None:
+        """Commit all SQL statements executed on the parent connection since the last
+        commit/rollback.  Note, this affects ALL cursors on the parent connection.
+        Hence, consider calling commit() on the parent Connection object instead.
+        """
+        ...
+
+    def rollback(self) -> None:
+        """Rollback all SQL statements executed on the parent connection since the last
+        commit/rollback.  Note, this affects ALL cursors on the parent connection.
+        Hence, consider calling rollback() on the parent Connection object instead.
+        """
+        ...
+
+    def cancel(self) -> None:
+        """Cancel the processing of the current query.  Typically this has to be called
+        from a separate thread.
+        """
+        ...
+
+    def close(self) -> None:
+        """Close the cursor, discarding any remaining result sets and/or messages."""
+        ...
 
 
-# a Row object represents a single database record, and behaves somewhat similar to a NamedTuple
+    # functions to retrieve database metadata
+
+    def tables(self,
+               table: Optional[str] = None,
+               catalog: Optional[str] = None,
+               schema: Optional[str] = None,
+               tableType: Optional[str] = None) -> Cursor:
+        """Return information about tables in the database, typically from the
+        INFORMATION_SCHEMA.TABLES metadata view.  Parameter values can include
+        wildcard characters.
+
+        Args:
+            table: Name of the database table.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+            tableType: Kind of table, e.g. "BASE TABLE".
+
+        Returns:
+            The cursor object, containing table information in the result set.
+        """
+        ...
+
+    def columns(self,
+                table: Optional[str] = None,
+                catalog: Optional[str] = None,
+                schema: Optional[str] = None,
+                column: Optional[str] = None) -> Cursor:
+        """Return information about columns in database tables, typically from the
+        INFORMATION_SCHEMA.COLUMNS metadata view.  Parameter values can include
+        wildcard characters.
+
+        Args:
+            table: Name of the database table.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+            column: Name of the column in the table.
+
+        Returns:
+            The cursor object, containing column information in the result set.
+        """
+        ...
+
+    def statistics(self,
+                   table: str,
+                   catalog: Optional[str] = None,
+                   schema: Optional[str] = None,
+                   unique: bool = False,
+                   quick: bool = True) -> Cursor:
+        """Return statistical information about database tables.  Parameter values
+        can include wildcard characters.
+
+        Args:
+            table: Name of the database table.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+            unique: If True, include information about unique indexes only, not all indexes.
+            quick: If True, CARDINALITY and PAGES are returned only if they are readily
+                available, otherwise None is returned for them.
+
+        Returns:
+            The cursor object, containing statistical information in the result set.
+        """
+        ...
+
+    def rowIdColumns(self,
+                     table: str,
+                     catalog: Optional[str] = None,
+                     schema: Optional[str] = None,
+                     nullable: bool = True) -> Cursor:
+        """Return the column(s) in a database table that uniquely identify each row
+        (e.g. the primary key column).  Parameter values can include wildcard characters.
+
+        Args:
+            table: Name of the database table.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+            nullable: If True, include sets of columns that are nullable.
+
+        Returns:
+            The cursor object, containing the relevant column information in the result set.
+        """
+        ...
+
+    def rowVerColumns(self,
+                      table: str,
+                      catalog: Optional[str] = None,
+                      schema: Optional[str] = None,
+                      nullable: bool = True) -> Cursor:
+        """Return the column(s) in a database table that are updated whenever the row
+        is updated.  Parameter values can include wildcard characters.
+
+        Args:
+            table: Name of the database table.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+            nullable: If True, include sets of columns that are nullable.
+
+        Returns:
+            The cursor object, containing the relevant column information in the result set.
+        """
+        ...
+
+    def primaryKeys(self,
+                    table: str,
+                    catalog: Optional[str] = None,
+                    schema: Optional[str] = None) -> Cursor:
+        """Return the column(s) in a database table that make up the primary key on
+        the table.  Parameter values can include wildcard characters.
+
+        Args:
+            table: Name of the database table.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+
+        Returns:
+            The cursor object, containing primary key information in the result set.
+        """
+        ...
+
+    def foreignKeys(self,
+                    table: Optional[str] = None,
+                    catalog: Optional[str] = None,
+                    schema: Optional[str] = None,
+                    foreignTable: Optional[str] = None,
+                    foreignCatalog: Optional[str] = None,
+                    foreignSchema: Optional[str] = None) -> Cursor:
+        """Return the foreign keys in a database table, i.e. any columns that refer to
+        primary key columns on another table.  Parameter values can include wildcard characters.
+
+        Args:
+            table: Name of the database table.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+            foreignTable: Name of the foreign database table.
+            foreignCatalog: Name of the foreign catalog (database).
+            foreignSchema: Name of the foreign table schema.
+
+        Returns:
+            The cursor object, containing foreign key information in the result set.
+        """
+        ...
+
+    def procedures(self,
+                   procedure: Optional[str] = None,
+                   catalog: Optional[str] = None,
+                   schema: Optional[str] = None) -> Cursor:
+        """Return information about stored procedures.  Parameter values can include
+        wildcard characters.
+
+        Args:
+            procedure: Name of the stored procedure.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+
+        Returns:
+            The cursor object, containing stored procedure information in the result set.
+        """
+        ...
+
+    def procedureColumns(self,
+                         procedure: Optional[str] = None,
+                         catalog: Optional[str] = None,
+                         schema: Optional[str] = None) -> Cursor:
+        """Return information about the columns used as input/output parameters in
+        stored procedures.  Parameter values can include wildcard characters.
+
+        Args:
+            procedure: Name of the stored procedure.
+            catalog: Name of the catalog (database).
+            schema: Name of the table schema.
+
+        Returns:
+            The cursor object, containing stored procedure column information in the result set.
+        """
+        ...
+
+    def getTypeInfo(self, sqlType: Optional[int] = None, /) -> Cursor:
+        """Return information about data types supported by the data source.
+
+        Args:
+            sqlType: The SQL data type.
+
+        Returns:
+            The cursor object, containing information about the SQL data type in the result set.
+        """
+        ...
+
+
 class Row:
-    cursor_description: Tuple[Tuple[str, Any, int, int, int, int, bool]]
+    """The class representing a single record in the result set from a query.  Objects of
+    this class behave somewhat similarly to a NamedTuple.  Column values can be accessed
+    by column name (i.e. using dot notation) or by row index.
+    """
+
+    @property
+    def cursor_description(self) -> RowDescription:
+        """The metadata for the columns in this Row, as retrieved from the parent Cursor object."""
+        ...
 
     # implemented dunder methods
     def __contains__(self, key, /) -> int: ...
@@ -437,13 +937,45 @@ class Row:
 
 # module functions
 
-def dataSources() -> Dict[str, str]: ...
-def drivers() -> List[str]: ...
+def dataSources() -> Dict[str, str]:
+    """Return all available Data Source Names (DSNs), typically from the odbcinst.ini file
+    or the Windows ODBC Data Source Administrator.
 
-def setDecimalSeparator(sep: str, /) -> None: ...
-def getDecimalSeparator() -> str: ...
+    Returns:
+        A dictionary of DSNs and their textual descriptions.
+    """
+    ...
 
-# https://www.python.org/dev/peps/pep-0249/#connect
+def drivers() -> List[str]:
+    """Return the names of all available ODBC drivers, typically from the odbc.ini file or the
+    Windows ODBC Data Source Administrator.
+
+    Returns:
+        A list of driver names.
+    """
+    ...
+
+
+def getDecimalSeparator() -> str:
+    """Retrieve the decimal separator character used when parsing NUMERIC/DECIMAL values
+    from the database, e.g. the "." in "1,234.56".
+
+    Returns:
+        The decimal separator character.
+    """
+    ...
+
+
+def setDecimalSeparator(sep: str, /) -> None:
+    """Set the decimal separator character used when parsing NUMERIC/DECIMAL values
+    from the database, e.g. the "." in "1,234.56".
+
+    Args:
+        sep: The decimal separator character.
+    """
+    ...
+
+
 def connect(connstring: Optional[str] = None,
             /, *,  # only positional parameters before, only named parameters after
             autocommit: bool = False,
@@ -452,4 +984,23 @@ def connect(connstring: Optional[str] = None,
             readonly: bool = False,
             timeout: int = 0,
             attrs_before: Dict[int, Any] = {},
-            **kwargs: Any) -> Connection: ...
+            **kwargs: Any) -> Connection:
+    """Create a new ODBC connection to a database.  See the Wiki for details:
+    https://github.com/mkleehammer/pyodbc/wiki/The-pyodbc-Module#connect
+
+    Args:
+        connstring: The connection string, which is passed verbatim to the driver manager.
+        autocommit: If True, instructs the database to commit after each SQL statement.
+        encoding: Encoding codec used when sending textual connection parameters to the database.
+        ansi: Can be set True for drivers that do not support Unicode.  This is rare.
+        readonly: To set the connection read-only.  Not all drivers and/or databases support this.
+        timeout: Set the connection timeout, in seconds.  This is managed by the driver, not
+            pyodbc, and not all drivers support this.
+        attrs_before: Set low-level connection attributes before a connection is attempted.
+        **kwargs: These key/value pairs are used to construct the connection string, or add
+            to it (as "key=value;" combinations).
+
+    Returns:
+        A new Connection object.
+    """
+    ...


### PR DESCRIPTION
This PR enhances the existing `pyodbc.pyi` file by:

- adding docstrings to the module functions, classes, class methods, and class properties
- adding missing parameters to various methods that didn't have them before
- making corrections to a few function signatures
- setting class properties correctly with `@property` (specifically r/o or r/w)

The docstrings are in [Google format](https://google.github.io/styleguide/pyguide.html), although I should say I haven't stuck rigidly to that guide.

The docstrings I've added don't attempt to provide a full description for every function.  The behavior of many functions is complex and I believe the Wiki is still the best place to provide comprehensive documentation.  My intention is to enhance the experience for developers by adding more summary info to the popups often seen in PyCharm, VSCode, etc.

I'm aware that `List[]` and `Dict[]` can generally be used in their base form (`list[]` and `dict[]`) but I stuck with `List[]` and `Dict[]` in this PR for consistency.  Ditto for `Optional` and `| None`.

This PR does make use of the relatively new `typing.TypeAlias` annotation which is available only in 3.10+ (also `typing.Final` from 3.8).  I don't think this should be an issue because this shouldn't affect running code and linters should probably be using the latest version of Python anyway, but if anybody thinks this is problematic, let me know.

Also, the build is failing for Python 3.6 because Github Action's runner `ubuntu-latest` was recently upgraded from 20.04 to 22.04, and 22.04 is not available for Python 3.6 in Github Actions.  (Another reason for dropping 2.7/3.6.)