### PR TITLE
Drop official support for Python 2.7 and 3.6

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -11,10 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "2.7"
-            tests-dir: tests2
-          - python-version: "3.6"
-            tests-dir: tests3
           - python-version: "3.7"
             tests-dir: tests3
           - python-version: "3.8"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,23 +53,6 @@ environment:
     # all the Python versions to be tested, both 32-bit and 64-bit
     # ref: https://www.appveyor.com/docs/windows-images-software/#python
 
-    # Python 2.7 must be built with Visual Studio 9.0, which is available only
-    # on AppVeyor Windows images Visual Studio 2013 and Visual Studio 2015
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PYTHON_HOME: "C:\\Python27"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PYTHON_HOME: "C:\\Python27-x64"
-
-    # Python 3.5+ need at least the Visual Studio 2015 image
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON_HOME: "C:\\Python36"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON_HOME: "C:\\Python36-x64"
-
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_HOME: "C:\\Python37"
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ OFFICIAL_BUILD = 9999
 
 # This version identifier should refer to the NEXT release, not the
 # current one.  After each release, the version should be incremented.
-VERSION = '4.0.35'
+VERSION = '5.0.0'
 
 
 def _print(s):
@@ -100,7 +100,7 @@ def main():
 
         'license': 'MIT',
 
-        'python_requires': '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
+        'python_requires': '>=3.7',
 
         'classifiers': ['Development Status :: 5 - Production/Stable',
                        'Intended Audience :: Developers',
@@ -109,10 +109,7 @@ def main():
                        'Operating System :: Microsoft :: Windows',
                        'Operating System :: POSIX',
                        'Programming Language :: Python',
-                       'Programming Language :: Python :: 2',
-                       'Programming Language :: Python :: 2.7',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',
                        'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This is a potential minimalistic PR for dropping official support for Python 2.7 and 3.6.  This PR does not remove any 2.7 code but it would at least mark a formal transition to the Python 3.7+ only version of pyodbc.