### PR TITLE
Correct the install location of `pyodbc.pyi`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,9 @@ def main():
 
         'ext_modules': [Extension('pyodbc', sorted(files), **settings)],
 
-        'package_dir': {'': 'src'},
         'packages': [''],
-        'package_data': {'': ["pyodbc.pyi"]},  # places pyodbc.pyi alongside pyodbc.py in site-packages
+        'package_dir': {'': 'src'},
+        'package_data': {'': ['pyodbc.pyi']},  # places pyodbc.pyi alongside pyodbc.{platform}.{pyd|so} in site-packages
 
         'license': 'MIT',
 

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,9 @@ def main():
 
         'ext_modules': [Extension('pyodbc', sorted(files), **settings)],
 
-        'data_files': [
-            ('', ['src/pyodbc.pyi'])  # places pyodbc.pyi alongside pyodbc.py in site-packages
-        ],
+        'package_dir': {'': 'src'},
+        'packages': [''],
+        'package_data': {'': ["pyodbc.pyi"]},  # places pyodbc.pyi alongside pyodbc.py in site-packages
 
         'license': 'MIT',
 


### PR DESCRIPTION
Use `package*` keyword and correct the installation location of `pyodbc.pyi` instead of the deprecated `data_files` keyword usage. This PR is the direct solution of #925.