### PR TITLE
Musllinux wheels

### DIFF
--- a/.github/workflows/artifacts_build.yml
+++ b/.github/workflows/artifacts_build.yml
@@ -72,7 +72,7 @@ jobs:
               {wheel}
 
           # Build choices - disable musl Linux and PyPy builds
-          CIBW_SKIP: "*-musllinux_* pp*"
+          CIBW_SKIP: "pp*"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel.linux]
+before-all = "yum install unixODBC-devel"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = "apk add unixodbc-dev gcc g++"


### PR DESCRIPTION
Added overrides to the cibuildwheel config so that the correct packages are installed for musllinux. 
