### PR TITLE
Don't use py3.10 TypeAlias in pyodbc.pyi

### DIFF
--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -1,13 +1,8 @@
 from __future__ import annotations
 from typing import (
     Any, Callable, Dict, Final, Generator, Iterable, Iterator,
-    List, Optional, Sequence, Tuple, TypeAlias, Union,
+    List, Optional, Sequence, Tuple, Union,
 )
-
-# ref: https://peps.python.org/pep-0249/#description
-FieldDescription: TypeAlias = Tuple[str, Any, int, int, int, int, bool]
-RowDescription: TypeAlias = Tuple[FieldDescription]
-
 
 
 # SQLSetConnectAttr attributes
@@ -533,7 +528,7 @@ class Cursor:
         ...
 
     @property
-    def description(self) -> RowDescription:
+    def description(self) -> Tuple[Tuple[str, Any, int, int, int, int, bool]]:
         """The metadata for the columns returned in the last SQL SELECT statement, in
         the form of a list of tuples.  Each tuple contains seven fields:
 
@@ -544,6 +539,8 @@ class Cursor:
         4. precision
         5. scale
         6. nullable (True/False)
+
+        ref: https://peps.python.org/pep-0249/#description
         """
         ...
 
@@ -912,7 +909,7 @@ class Row:
     """
 
     @property
-    def cursor_description(self) -> RowDescription:
+    def cursor_description(self) -> Tuple[Tuple[str, Any, int, int, int, int, bool]]:
         """The metadata for the columns in this Row, as retrieved from the parent Cursor object."""
         ...
 


### PR DESCRIPTION
Re #1186 , the typing construct `TypeAlias` was introduced in Python 3.10.  This is causing mypy issues with people who are using older versions of Python.  Hence, drop the `TypeAlias` references in `pyodbc.pyi` and just use the raw typing definition for cursor descriptions.  This appears to solve the mypy issue:

```
(pyodbcpyi38) C:\Users\toast>mypy C:\Users\toast\Documents\GitHub\forks\pyodbc\src\pyodbc.pyi
Success: no issues found in 1 source file
```

Note, the `Final` typing references are being kept, despite them being introduced only in Python 3.8.