### PR TITLE
PEP-440 install error with bad characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,10 @@ def _get_version_git():
         pass
     else:
         if result != 'master' and not re.match(r'^v\d+$', result):
-            name = name + '+' + result.replace('-', '')
+            result = result.replace('-', '')
+            if '/' in result:
+                result = result.replace('/', '_')
+            name = name + '+' + result
 
     return name, numbers
 


### PR DESCRIPTION
This commit modifies `setup.py` and removes characters that could be in a local branch that are incompatible with PEP-440.

Resolves #1202