### PR TITLE
Allow python exception handling for empty iterator

### DIFF
--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1177,11 +1177,6 @@ static bool GetByteArrayInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Par
 // TVP
 static bool GetTableInfo(Cursor *cur, Py_ssize_t index, PyObject* param, ParamInfo& info)
 {
-    if (!PyIter_Check(param))
-    {
-        PyErr_SetString(PyExc_ValueError, "The given sequence was empty.");
-        return false;
-    }
     int nskip = 0;
     Py_ssize_t nrows = PySequence_Size(param);
     if (nrows > 0)

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1177,6 +1177,11 @@ static bool GetByteArrayInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Par
 // TVP
 static bool GetTableInfo(Cursor *cur, Py_ssize_t index, PyObject* param, ParamInfo& info)
 {
+    if (!PyIter_Check(param))
+    {
+        PyErr_SetString(PyExc_ValueError, "The given sequence was empty.");
+        return false;
+    }
     int nskip = 0;
     Py_ssize_t nrows = PySequence_Size(param);
     if (nrows > 0)

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1188,6 +1188,10 @@ static bool GetTableInfo(Cursor *cur, Py_ssize_t index, PyObject* param, ParamIn
     {
         PyObject *cell0 = PySequence_GetItem(param, 0);
         Py_XDECREF(cell0);
+        if (cell0 == NULL)
+        {
+            return false;
+        }
         if (PyBytes_Check(cell0) || PyUnicode_Check(cell0))
         {
             nskip++;


### PR DESCRIPTION
This commit allows Python to handle empty iterators given to a `pyodbc` connection instead of issuing a segfault. See the below code for an example of what would normally result in a segfault.

```python
import collections
import pyodbc

class MySequence(collections.abc.Sequence):
    def __getitem__(self, index):
        ...

    def __len__(self):
        return 1

connection = pyodbc.connect(...)
connection.execute("SELECT ?, ?", 123, MySequence()).fetchone()
```