### PR TITLE
Get the diagnostics messages more often

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -11,8 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "2.7"
-            tests-dir: tests2
           - python-version: "3.6"
             tests-dir: tests3
           - python-version: "3.7"
@@ -161,7 +159,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -1549,6 +1549,29 @@ class SqlServerTestCase(unittest.TestCase):
             self.cursor.fetchall()
         self.assertEqual(self.cursor.messages, [])
 
+    def test_cursor_messages_with_trigger(self):
+        self.cursor.execute("DROP TABLE IF EXISTS t1")
+        self.cursor.execute("CREATE TABLE t1(id INT IDENTITY PRIMARY KEY, name NVARCHAR(255) NULL)")
+        self.cursor.execute("""
+            CREATE TRIGGER [dbo].[trg_t1] ON t1
+            AFTER INSERT
+            AS
+            BEGIN
+                SET NOCOUNT ON;
+                PRINT 'ABC';
+            END
+        """)
+        self.cursor.execute("INSERT INTO t1(name) SELECT NEWID()")
+        messages = self.cursor.messages
+        self.assertTrue(type(messages) is list)
+        self.assertEqual(len(messages), 1)
+        self.assertTrue(type(messages[0]) is tuple)
+        self.assertEqual(len(messages[0]), 2)
+        self.assertTrue(type(messages[0][0]) is unicode)
+        self.assertTrue(type(messages[0][1]) is unicode)
+        self.assertEqual('[01000] (0)', messages[0][0])
+        self.assertTrue(messages[0][1].endswith('ABC'))
+
     def test_none_param(self):
         "Ensure None can be used for params other than the first"
         # Some driver/db versions would fail if NULL was not the first parameter because SQLDescribeParam (only used


### PR DESCRIPTION
Diagnostic messages (e.g. SQL error messages) are retrieved after executing a SQL query.  However, the diagnostic messages were being retrieved only for a return value of SQL_SUCCESS_WITH_INFO.  This should be extended for other return values.

Function GetDiagRecs has been changed to add diagnostic messages to the "messages" cursor attribute rather than replace the attribute.  Deciding when to clear the "messages" attribute should happen outside GetDiagRecs.

Fixes #1238 .

Note, Github Actions [no longer supports Python 2.7](https://github.com/actions/setup-python/issues/672).

Ref:
https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/return-codes-odbc
https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlexecdirect-function?view=sql-server-ver16#returns
https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlmoreresults-function?view=sql-server-ver16#returns