### PR TITLE
Don't build MacOS ARM64 distributions

### DIFF
--- a/.github/workflows/artifacts_build.yml
+++ b/.github/workflows/artifacts_build.yml
@@ -32,6 +32,8 @@ jobs:
     strategy:
       matrix:
         # https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job
+        # ubuntu-20.04 supports more versions of Python than ubuntu-22.04
+        # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         os: [windows-2019, macos-11, ubuntu-20.04]
 
     steps:
@@ -45,14 +47,15 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.13.1
         # https://cibuildwheel.readthedocs.io/en/stable/options/#options-summary
         env:
           # Windows - both 64-bit and 32-bit builds
           CIBW_ARCHS_WINDOWS: "AMD64 x86"
 
-          # macOS - both Intel and ARM builds; no bundled libraries
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          # macOS - just Intel build (ARM doesn't work); no bundled libraries
+          # https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile
+          CIBW_ARCHS_MACOS: x86_64
           # prevent the addition of unixODBC dylibs to the wheel by simply not calling the repair
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -5,14 +5,16 @@ on: [push, pull_request]
 jobs:
   run_tests:
     name: Run tests on Python ${{ matrix.python-version }}
+    # ubuntu-20.04 supports more versions of Python than ubuntu-22.04
+    # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
     runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
       matrix:
+        # Github Actions no longer supports Python 2.7 (June 2023)
+        # https://github.com/actions/runner-images/issues/7401
         include:
-          - python-version: "2.7"
-            tests-dir: tests2
           - python-version: "3.6"
             tests-dir: tests3
           - python-version: "3.7"
@@ -161,7 +163,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
The MacOS ARM64 distribution files from CIBUILDWHEEL are not working and I don't know why.  I was hoping they would eventually work with newer versions of cibuildwheel, etc. but that doesn't appear to be the case.  Hence, I'd like to remove the MacOS ARM64 distribution builds from Github Actions.

We will have to figure out a different way of generating the MacOS ARM64 distribution files.  (FYI, I personally don't have access to an ARM64 MacOS laptop so my options are limited.)  Meanwhile, users will have to build their pip installations from source, which is what we recommend anyway.

Also, other tidy ups to the Github Action config files.