### PR TITLE
Don't call setup.py directly in AppVeyor

### DIFF
--- a/appveyor/after_test.cmd
+++ b/appveyor/after_test.cmd
@@ -1,12 +1,13 @@
 IF "%APVYR_GENERATE_WHEELS%" == "true" (
-  ECHO *** pip install the "wheel" module
-  "%PYTHON_HOME%\python" -m pip install wheel --quiet --no-warn-script-location
+  ECHO *** pip install build/wheel modules
+  "%PYTHON_HOME%\python" -m pip install build wheel --quiet --no-warn-script-location
   ECHO.
   ECHO *** Generate the wheel file
-  %WITH_COMPILER% "%PYTHON_HOME%\python" setup.py bdist_wheel
+  %WITH_COMPILER% "%PYTHON_HOME%\python" -m build --wheel --no-isolation
   ECHO.
   ECHO *** \dist directory listing:
   DIR /B dist
+  ECHO.
 ) ELSE (
   ECHO *** Skipping generation of the wheel file
   ECHO.

--- a/appveyor/build_script.cmd
+++ b/appveyor/build_script.cmd
@@ -32,14 +32,6 @@ IF ERRORLEVEL 1 (
 "%PYTHON_HOME%\python" -m pip freeze --all
 
 ECHO.
-ECHO *** Building the pyodbc module...
-%WITH_COMPILER% "%PYTHON_HOME%\python" setup.py build
-IF ERRORLEVEL 1 (
-  ECHO *** ERROR: pyodbc build failed
-  EXIT 1
-)
-
-ECHO.
 ECHO *** Installing pyodbc...
 "%PYTHON_HOME%\python" -m pip install .
 IF ERRORLEVEL 1 (

--- a/appveyor/install.cmd
+++ b/appveyor/install.cmd
@@ -1,3 +1,3 @@
 ECHO *** pip install pytest and other dev requirements ***
-"%PYTHON_HOME%\python" -m pip install -r requirements-dev.txt
+"%PYTHON_HOME%\python" -m pip install -r requirements-dev.txt --quiet --no-warn-script-location
 ECHO.

--- a/appveyor/install.cmd
+++ b/appveyor/install.cmd
@@ -1,2 +1,3 @@
 ECHO *** pip install pytest and other dev requirements ***
 "%PYTHON_HOME%\python" -m pip install -r requirements-dev.txt
+ECHO.


### PR DESCRIPTION
A small change, but we are being [discouraged ](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html) from calling `setup.py` directly.  Hence, this PR.

Note, the `setup.py build` command in appveyor/build_script.cmd wasn't actually needed so I've removed that.

Here's the deprecation warning in the AppVeyor [output log](https://ci.appveyor.com/project/mkleehammer/pyodbc/builds/47887868/job/8emc4jdyjodbi3aw):
`C:\Python311-x64\Lib\site-packages\setuptools\_distutils\cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.`