### PR TITLE
Add the closed() connection attribute to pyodbc.pyi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ x86/
 # Linters
 .flake8
 .pylintrc
+.ruff_cache/
+ruff.toml
 
 # Other
 pyodbc.conf

--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -349,6 +349,11 @@ class Connection:
         ...
 
     @property
+    def closed(self) -> bool:
+        """Returns True if the connection is closed, False otherwise."""
+        ...
+
+    @property
     def maxwrite(self) -> int:
         """The maximum bytes to write before using SQLPutData, default is zero for no maximum."""
         ...
@@ -979,7 +984,7 @@ def connect(connstring: Optional[str] = None,
             encoding: str = 'utf-16le',
             readonly: bool = False,
             timeout: int = 0,
-            attrs_before: Dict[int, Any] = {},
+            attrs_before: Optional[Dict[int, Any]] = None,
             **kwargs: Any) -> Connection:
     """Create a new ODBC connection to a database.  See the Wiki for details:
     https://github.com/mkleehammer/pyodbc/wiki/The-pyodbc-Module#connect


### PR DESCRIPTION
The `closed()` read-only attribute was missing from `pyodbc.pyi`.

Also, fix the `attrs_before` parameter type hint on the `connect()` function in `pyodbc.pyi`.

Also, make Git ignore standalone ruff files (project-wide ruff setup would normally be defined in `pyproject.toml`).