### PR TITLE
Add the AppVeyor badge to the front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pyodbc
 
+[![Windows build](https://ci.appveyor.com/api/projects/status/github/mkleehammer/pyodbc?branch=master&svg=true&passingText=Windows%20build&failingText=Windows%20build)](https://ci.appveyor.com/project/mkleehammer/pyodbc)
 [![Ubuntu build](https://github.com/mkleehammer/pyodbc/actions/workflows/ubuntu_build.yml/badge.svg)](https://github.com/mkleehammer/pyodbc/actions/workflows/ubuntu_build.yml)
 [![PyPI](https://img.shields.io/pypi/v/pyodbc?color=brightgreen)](https://pypi.org/project/pyodbc/)
 
@@ -8,13 +9,13 @@ implements the [DB API 2.0](https://www.python.org/dev/peps/pep-0249) specificat
 
 The easiest way to install pyodbc is to use pip:
 
-    pip install pyodbc
+    python -m pip install pyodbc
 
 On Macs, you should probably install unixODBC first if you don't already have an ODBC
-driver manager installed, e.g. using `Homebrew`:
+driver manager installed.  For example, using the [homebrew](https://brew.sh/) package manager:
 
     brew install unixodbc
-    pip install pyodbc
+    python -m pip install pyodbc
 
 Similarly, on Unix you should make sure you have an ODBC driver manager installed before
 installing pyodbc.  See the [docs](https://github.com/mkleehammer/pyodbc/wiki/Install)
@@ -23,8 +24,8 @@ ODBC driver manager is built-in.)
 
 Precompiled binary wheels are provided for multiple Python versions on most Windows, macOS,
 and Linux platforms.  On other platforms pyodbc will be built from the source code.  Note,
-pyodbc contains C++ extensions so when building from source you will need a suitable C++
-compiler.  See the [docs](https://github.com/mkleehammer/pyodbc/wiki/Install) for details.
+pyodbc contains C++ extensions so you will need a suitable C++ compiler when building from
+source.  See the [docs](https://github.com/mkleehammer/pyodbc/wiki/Install) for details.
 
 [Documentation](https://github.com/mkleehammer/pyodbc/wiki)
 


### PR DESCRIPTION
This PR adds the AppVeyor badge to README so it can be seen on the front page of GitHub, etc.  Plus a few other tweaks.