### PR TITLE
Run the CICD tests

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -190,32 +190,32 @@ jobs:
         PYODBC_POSTGRESQL: "DRIVER={PostgreSQL Unicode};SERVER=localhost;PORT=5432;UID=postgres_user;PWD=postgres_pwd;DATABASE=test"
       run: |
         cd "$GITHUB_WORKSPACE"
-        pytest "./tests/postgresql_test.py"
+        python -m pytest "./tests/postgresql_test.py"
 
     - name: Run MySQL tests
       env:
         PYODBC_MYSQL: "DRIVER={MySQL ODBC 8.0 ANSI Driver};SERVER=localhost;UID=root;PWD=root;DATABASE=test;CHARSET=utf8mb4"
       run: |
         cd "$GITHUB_WORKSPACE"
-        pytest "./tests/mysql_test.py"
+        python -m pytest "./tests/mysql_test.py"
 
     - name: Run SQL Server 2017 tests
       env:
         PYODBC_SQLSERVER: "DRIVER={ODBC Driver 17 for SQL Server};SERVER=localhost,1401;UID=sa;PWD=StrongPassword2017;DATABASE=test"
       run: |
         cd "$GITHUB_WORKSPACE"
-        python "./tests/sqlserver_test.py"
+        python -m pytest "./tests/sqlserver_test.py"
 
     - name: Run SQL Server 2019 tests
       env:
         PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1402;UID=sa;PWD=StrongPassword2019;DATABASE=test;Encrypt=Optional"
       run: |
         cd "$GITHUB_WORKSPACE"
-        python "./tests/sqlserver_test.py"
+        python -m pytest "./tests/sqlserver_test.py"
 
     - name: Run SQL Server 2022 tests
       env:
         PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1403;UID=sa;PWD=StrongPassword2022;DATABASE=test;Encrypt=Optional"
       run: |
         cd "$GITHUB_WORKSPACE"
-        python "./tests/sqlserver_test.py"
+        python -m pytest "./tests/sqlserver_test.py"

--- a/appveyor/test_script.cmd
+++ b/appveyor/test_script.cmd
@@ -56,11 +56,11 @@ IF ERRORLEVEL 1 (
   ECHO "%PYODBC_SQLSERVER%"
   GOTO :mssql3
 )
-SET PYTHON_ARGS=""
+SET PYTHON_ARGS="%PYTHON_HOME%\python" -m pytest
 IF "%APVYR_VERBOSE%" == "true" (
   SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
 )
-"%PYTHON_HOME%\python" "tests\sqlserver_test.py" %PYTHON_ARGS%
+%PYTHON_ARGS% "tests\sqlserver_test.py"
 IF ERRORLEVEL 1 SET OVERALL_RESULT=1
 
 
@@ -76,11 +76,11 @@ IF ERRORLEVEL 1 (
   SET OVERALL_RESULT=1
   GOTO :mssql4
 )
-SET PYTHON_ARGS=""
+SET PYTHON_ARGS="%PYTHON_HOME%\python" -m pytest
 IF "%APVYR_VERBOSE%" == "true" (
   SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
 )
-"%PYTHON_HOME%\python" "tests\sqlserver_test.py" %PYTHON_ARGS%
+%PYTHON_ARGS% "tests\sqlserver_test.py"
 IF ERRORLEVEL 1 SET OVERALL_RESULT=1
 
 :mssql4
@@ -95,11 +95,11 @@ IF ERRORLEVEL 1 (
   SET OVERALL_RESULT=1
   GOTO :mssql5
 )
-SET PYTHON_ARGS=""
+SET PYTHON_ARGS="%PYTHON_HOME%\python" -m pytest
 IF "%APVYR_VERBOSE%" == "true" (
   SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
 )
-"%PYTHON_HOME%\python" "tests\sqlserver_test.py" %PYTHON_ARGS%
+%PYTHON_ARGS% "tests\sqlserver_test.py"
 IF ERRORLEVEL 1 SET OVERALL_RESULT=1
 
 :mssql5
@@ -114,11 +114,11 @@ IF ERRORLEVEL 1 (
   SET OVERALL_RESULT=1
   GOTO :mssql6
 )
-SET PYTHON_ARGS=""
+SET PYTHON_ARGS="%PYTHON_HOME%\python" -m pytest
 IF "%APVYR_VERBOSE%" == "true" (
   SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
 )
-"%PYTHON_HOME%\python" "tests\sqlserver_test.py" %PYTHON_ARGS%
+%PYTHON_ARGS% "tests\sqlserver_test.py"
 IF ERRORLEVEL 1 SET OVERALL_RESULT=1
 
 :mssql6
@@ -133,11 +133,11 @@ IF ERRORLEVEL 1 (
   SET OVERALL_RESULT=1
   GOTO :postgresql
 )
-SET PYTHON_ARGS=""
+SET PYTHON_ARGS="%PYTHON_HOME%\python" -m pytest
 IF "%APVYR_VERBOSE%" == "true" (
   SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
 )
-"%PYTHON_HOME%\python" "tests\sqlserver_test.py" %PYTHON_ARGS%
+%PYTHON_ARGS% "tests\sqlserver_test.py"
 IF ERRORLEVEL 1 SET OVERALL_RESULT=1
 
 
@@ -170,11 +170,11 @@ IF ERRORLEVEL 1 (
   SET OVERALL_RESULT=1
   GOTO :mysql
 )
-SET PYTHON_ARGS=""
+SET PYTHON_ARGS="%PYTHON_HOME%\python" -m pytest
 IF "%APVYR_VERBOSE%" == "true" (
   SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
 )
-"%PYTHON_HOME%\python" "tests\postgresql_test.py" %PYTHON_ARGS%
+%PYTHON_ARGS% "tests\postgresql_test.py"
 IF ERRORLEVEL 1 SET OVERALL_RESULT=1
 
 
@@ -205,11 +205,11 @@ IF ERRORLEVEL 1 (
   SET OVERALL_RESULT=1
   GOTO :end
 )
-SET PYTHON_ARGS=""
+SET PYTHON_ARGS="%PYTHON_HOME%\python" -m pytest
 IF "%APVYR_VERBOSE%" == "true" (
   SET PYTHON_ARGS=%PYTHON_ARGS% --verbose
 )
-"%PYTHON_HOME%\python" "tests\mysql_test.py" %PYTHON_ARGS%
+%PYTHON_ARGS% "tests\mysql_test.py"
 IF ERRORLEVEL 1 SET OVERALL_RESULT=1
 
 


### PR DESCRIPTION
The CICD pipelines were running only the PostgreSQL and MySQL unit tests on Linux, because the tests were not being run using pytest.  This PR fixes that.  Also, strictly speaking, pytest should be run as a module with the `-m` option (i.e. `python -m pytest`) so I made those amendments too.

There is one test that is failing and I don't know why.  Here is the output:
```
__________________________ test_geometry_null_insert __________________________
cursor = <pyodbc.Cursor object at 0x0364EDA0>
    @pytest.mark.skipif(sys.platform.startswith('linux'),
                        reason='SQL Server Linux does not support -151 yet')
    def test_geometry_null_insert(cursor: pyodbc.Cursor):
        cnxn = connect()
    
        def convert(value):
            return value
    
        cnxn.add_output_converter(-151, convert)  # -151 is SQL Server's geometry
        cursor.execute("create table t1(n int, v geometry)")
        cursor.execute("insert into t1 values (?, ?)", 1, None)
>       value = cursor.execute("select v from t1").fetchone()[0]
E       pyodbc.ProgrammingError: ('ODBC SQL type -151 is not yet supported.  column-index=0  type=-151', 'HY106')
tests\sqlserver_test.py:1273: ProgrammingError
```
On the face of it, the code looks correct.  The only thing I can think of that -151 is a negative number and hence might throw things off somewhere, but I'm just guessing.  It's always a SQL_SMALLINT so would appear to be fine.  Help would be appreciated debugging this.