### PR TITLE
Location of pyodbc.pyi on install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include src/*.h
 include src/*.cpp
-include tests2/*
-include tests3/*
+include tests/*
 include README.*
 include LICENSE.txt
 

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,10 @@ def main():
         maintainer_email="michael@kleehammer.com",
         url='https://github.com/mkleehammer/pyodbc',
         ext_modules=[Extension('pyodbc', sorted(files), **settings)],
-        data_files=[
-            ('', ['src/pyodbc.pyi'])  # places pyodbc.pyi alongside pyodbc.py in site-packages
-        ],
+        include_package_data=False,
+        packages=[''],
+        package_dir={'': 'src'},
+        package_data={'': ['pyodbc.pyi']},  # places pyodbc.pyi alongside pyodbc.{platform}.{pyd|so} in site-packages
         license='MIT',
         python_requires='>=3.7',
         classifiers=['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The stub file pyodbc.pyi needs special care when generating the wheel, to ensure it is placed in the "site-packages" directory on install.  The relevant setup.py code was reverted recently, so I have re-reverted it back.  Apparently, we also need to set "include package data" to False now (because it is defaulted to True when using pyproject.toml).

FYI, this code (or at least its equivalent) does not work in pyproject.toml, hence it must remain in setup.py for the time being.

Also, quick fix for MANIFEST.in.