### PR TITLE
Update tox for version 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wheelhouse/
 # Unit test / coverage reports
 .tox/
 .coverage
+pytest.ini
 
 # Virtual Environments
 /venv*

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,41 @@
 # USAGE
-# First, install tox.  Tox should typically be available from the command line so it
+# First, install tox.  Tox should typically be available from the command line, so it
 # is recommended to install it using pipx (pipx install tox).
 #
-# Run tests against SQL Server, Postgres, and MySQL databases by providing connection
-# strings as parameters, for example:
-#   tox -- --sqlserver "DSN=localhost19" --postgresql "DSN=pg11" --mysql "DSN=mysql57"
-# You can test against multiple versions of the same database, here with added verbosity:
-#   tox -- --sqlserver "DSN=localhost17" --sqlserver "DSN=localhost19" -v
-# Run tests with specific names by using the -k option (per pytest), here in quiet mode:
-#   tox -- --sqlserver "DSN=localhost17" -k "unicode" -q
-# Note the use of "--" to separate the "tox" parameters from the parameters for the
-# tests.
+# The unit test scripts get database connection strings from environment variables,
+# and those values should be stored in a "pytest.ini" configuration file in this
+# directory.  Here is an example of pytest.ini:
 #
-# Alternatively, database connection info can be provided in a configuration file, in
-# the standard INI format.  The default filename is "tmp/database.cfg" within this repo,
-# but this can be overriden with the PYODBC_DATABASE_CFG environment variable.  Here
-# is an example of a suitable configuration file:
-#   [sqlserver_2017]
-#   DSN=localhost17
+# [pytest]
+# env =
+#     PYODBC_SQLSERVER=DSN=pyodbc-sqlserver
+#     PYODBC_POSTGRESQL=DSN=pyodbc-postgres
+#     PYODBC_MYSQL=DSN=mysql;charset=utf8mb4
+# # addopts=-rA --disable-warnings
+# # pythonpath=.
 #
-#   [sqlserver_2019]
-#   DSN=localhost19
-#
-#   [POSTGRES]
-#   user     = test
-#   password = test_password
-# Any section names beginning with "sqlserver", "postgres" or "mysql" (case-insensitive)
-# will be used for testing.  The key/value pairs in each section will be used to connect
-# to the relevant database.
+# Set PYODBC_SQLSERVER, PYODBC_POSTGRESQL, and PYODBC_MYSQL accordingly.
 #
 # Naturally, test databases must be up and available before running the tests.
-# Currently, only SQL Server, PostgreSQL, and MySQL are supported through tox.
-# Python 2.7 is not supported.
+# Run the unit tests against multiple versions of Python by calling "tox" from
+# this directory.  To run tests against only one version of Python, call, for
+# example, "tox -e py37".
+# To run tests against only certain databases, comment out the relevant "pytest"
+# commands below.
+# To override the pytest default parameters, use "--", e.g. "tox -e py37 -- -rA".
 
 [tox]
 skipsdist = true
+env_list = py{37,38,39,310,311}
 
-[testenv:unit_tests]
+[testenv]
 description = Run the pyodbc unit tests
-deps = -r requirements-test.txt
+deps =
+    pytest
+    pytest-env
 sitepackages = false
 commands =
-    python -m pip install --force-reinstall --no-deps .
-    python .{/}tests3{/}run_tests.py {posargs}
+    python -m pip install --quiet --force-reinstall --no-deps .
+    python -m pytest {posargs:--no-header --disable-warnings} ./tests/sqlserver_test.py
+    python -m pytest {posargs:--no-header --disable-warnings} ./tests/postgresql_test.py
+    python -m pytest {posargs:--no-header --disable-warnings} ./tests/mysql_test.py


### PR DESCRIPTION
This PR updates `tox.ini` to work with version 5 of pyodbc.  It runs the unit test scripts against Python versions 3.7 thru 3.11.   And it runs the unit test scripts for SQL Server, PostgreSQL, and MySQL, although it will be necessary for each developer to provide connection strings in a custom `pytest.ini` file.  Hence, `pytest.ini` is added to `.gitignore`.  If version-controlled parameters for tox are needed in the future, they should be added to the `pyproject.toml` file, not `pytest.ini`.