### PR TITLE
Add support for Python 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/artifacts_build.yml
+++ b/.github/workflows/artifacts_build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Python dependencies
         run: |
@@ -36,17 +36,17 @@ jobs:
         os: [windows-2019, macos-11, ubuntu-22.04]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         # QEMU is needed for Linux aarch64 wheels
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.15.0
         # https://cibuildwheel.readthedocs.io/en/stable/options/#options-summary
         env:
           # Windows - both 64-bit and 32-bit builds

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     services:
 

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     services:
 
@@ -157,12 +157,13 @@ jobs:
         echo "*** create database"
         mysql --user=root --password=root --execute "CREATE DATABASE test"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install Python dev dependencies
       # pyodbc doesn't have any Python dependencies, but we do need pytest for testing.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,12 +54,6 @@ environment:
     # ref: https://www.appveyor.com/docs/windows-images-software/#python
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON_HOME: "C:\\Python37"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON_HOME: "C:\\Python37-x64"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_HOME: "C:\\Python38"
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "pyodbc"
 version = "5.0.0b4"
 
-requires-python = ">=3.7"
-# This is used by the Github action that builds release artifacts using cibuildwheel.
+requires-python = ">=3.8"
+# This is used by the GitHub action that builds release artifacts using cibuildwheel.
 # cibuildwheel reads this directly:
 #
 # https://cibuildwheel.readthedocs.io/en/stable/options/#requires-python

--- a/setup.py
+++ b/setup.py
@@ -111,9 +111,8 @@ def get_compiler_settings():
         # made the settings.
         # https://lectem.github.io/msvc/reverse-engineering/build/2019/01/21/MSVC-hidden-flags.html
 
-        if sys.hexversion >= 0x03050000:
-            settings['extra_compile_args'].append('/d2FH4-')
-            settings['extra_link_args'].append('/d2:-FH4-')
+        settings['extra_compile_args'].append('/d2FH4-')
+        settings['extra_link_args'].append('/d2:-FH4-')
 
         settings['libraries'].append('odbc32')
         settings['libraries'].append('advapi32')

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main():
         package_dir={'': 'src'},
         package_data={'': ['pyodbc.pyi']},  # places pyodbc.pyi alongside pyodbc.{platform}.{pyd|so} in site-packages
         license='MIT',
-        python_requires='>=3.7',
+        python_requires='>=3.8',
         classifiers=['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',
                      'Intended Audience :: System Administrators',

--- a/src/decimal.cpp
+++ b/src/decimal.cpp
@@ -50,24 +50,13 @@ bool InitializeDecimal() {
     if (!point)
         return false;
 
-#if PY_MAJOR_VERSION >= 3
     pDecimalPoint = PyUnicode_FromString(".");
-#else
-    pDecimalPoint = PyBytes_FromString(".");
-#endif
 
     if (!pDecimalPoint)
         return false;
 
-#if PY_MAJOR_VERSION >= 3
     if (!SetDecimalPoint(point))
         return false;
-#else
-    // In 2.7, we only support non-Unicode right now.
-    if (PyBytes_Check(point))
-        if (!SetDecimalPoint(point))
-            return false;
-#endif
 
     return true;
 }
@@ -106,11 +95,7 @@ bool SetDecimalPoint(PyObject* pNew)
         pLocaleDecimalEscaped = e.Detach();
     }
 
-#if PY_MAJOR_VERSION >= 3
     Object s(PyUnicode_FromFormat("[^0-9%U-]+", pLocaleDecimal));
-#else
-    Object s(PyBytes_FromFormat("[^0-9%s-]+", PyString_AsString(pLocaleDecimal)));
-#endif
     if (!s)
         return false;
 

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -663,11 +663,7 @@ static PyObject* mod_setdecimalsep(PyObject* self, PyObject* args)
 {
     UNUSED(self);
 
-#if PY_MAJOR_VERSION >= 3
     const char* type = "U";
-#else
-    const char* type = "S";
-#endif
 
     PyObject* p;
     if (!PyArg_ParseTuple(args, type, &p))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-
 # If pyodbc has not been installed in this virtual environment, add the appropriate build
 # directory.  This allows us to compile and run pytest without an install step in between
 # slowing things down.  If you are going to use this, do not install pyodbc.  If you already

--- a/tests/mysql_test.py
+++ b/tests/mysql_test.py
@@ -455,7 +455,7 @@ def test_emoticons_as_literal(cursor: pyodbc.Cursor):
     assert result == v
 
 
-@lru_cache()
+@lru_cache
 def _generate_str(length, encoding=None):
     """
     Returns either a string or bytes, depending on whether encoding is provided,

--- a/tests/old/accesstests.py
+++ b/tests/old/accesstests.py
@@ -144,12 +144,12 @@ class AccessTestCase(unittest.TestCase):
         """
         The implementation for string, Unicode, and binary tests.
         """
-        assert colsize is None or (value is None or colsize >= len(value)), 'colsize=%s value=%s' % (colsize, (value is None) and 'none' or len(value))
+        assert colsize is None or (value is None or colsize >= len(value)), 'colsize={} value={}'.format(colsize, (value is None) and 'none' or len(value))
 
         if colsize:
-            sql = "create table t1(n1 int not null, s1 %s(%s), s2 %s(%s))" % (sqltype, colsize, sqltype, colsize)
+            sql = "create table t1(n1 int not null, s1 {}({}), s2 {}({}))".format(sqltype, colsize, sqltype, colsize)
         else:
-            sql = "create table t1(n1 int not null, s1 %s, s2 %s)" % (sqltype, sqltype)
+            sql = "create table t1(n1 int not null, s1 {}, s2 {})".format(sqltype, sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(1, ?, ?)", (value, value))
@@ -263,7 +263,7 @@ class AccessTestCase(unittest.TestCase):
 
 
     def test_unicode_query(self):
-        self.cursor.execute(u"select 1")
+        self.cursor.execute("select 1")
         
     def test_negative_row_index(self):
         self.cursor.execute("create table t1(s varchar(20))")
@@ -400,7 +400,7 @@ class AccessTestCase(unittest.TestCase):
         self.assertEqual(False, result)
 
     def test_guid(self):
-        value = u"de2ac9c6-8676-4b0b-b8a6-217a8580cbee"
+        value = "de2ac9c6-8676-4b0b-b8a6-217a8580cbee"
         self.cursor.execute("create table t1(g1 uniqueidentifier)")
         self.cursor.execute("insert into t1 values (?)", value)
         v = self.cursor.execute("select * from t1").fetchone()[0]
@@ -566,8 +566,8 @@ class AccessTestCase(unittest.TestCase):
 
 
     def test_concatenation(self):
-        v2 = u'0123456789' * 25
-        v3 = u'9876543210' * 25
+        v2 = '0123456789' * 25
+        v3 = '9876543210' * 25
         value = v2 + 'x' + v3
 
         self.cursor.execute("create table t1(c2 varchar(250), c3 varchar(250))")
@@ -609,7 +609,7 @@ def main():
     shutil.copy(src, dest)
 
     global CNXNSTRING
-    CNXNSTRING = 'DRIVER={%s};DBQ=%s;ExtendedAnsiSQL=1' % (DRIVERS[args.type], dest)
+    CNXNSTRING = 'DRIVER={{{}}};DBQ={};ExtendedAnsiSQL=1'.format(DRIVERS[args.type], dest)
     print(CNXNSTRING)
 
     if args.verbose:

--- a/tests/old/sparktests.py
+++ b/tests/old/sparktests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 usage = """\
 %(prog)s [options] connection_string
@@ -150,7 +149,7 @@ class SparkTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {}({}))".format(sqltype, colsize)
         else:
             sql = "create table t1(s %s)" % sqltype
 
@@ -326,7 +325,7 @@ class SparkTestCase(unittest.TestCase):
         self.cursor = self.cnxn.cursor()
 
         self.cursor.execute("create table t1(c1 int, c2 int)")
-        self.cursor.execute("select c1 as {}, c2 as {} from t1".format(c1, c2))
+        self.cursor.execute(f"select c1 as {c1}, c2 as {c2} from t1")
 
         names = [ t[0] for t in self.cursor.description ]
         names.sort()

--- a/tests/old/sqldwtests.py
+++ b/tests/old/sqldwtests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
 x = 1 # Getting an error if starting with usage for some reason.
 
@@ -74,7 +73,7 @@ class SqlServerTestCase(unittest.TestCase):
             'freetds': 'FreeTDS ODBC',
         }
         if not type_name in recognized_types.keys():
-            raise KeyError('"{0}" is not a recognized driver type: {1}'.format(type_name, list(recognized_types.keys())))
+            raise KeyError(f'"{type_name}" is not a recognized driver type: {list(recognized_types.keys())}')
         driver_name = self.cnxn.getinfo(pyodbc.SQL_DRIVER_NAME).lower()
         if type_name == 'msodbcsql':
             return ('msodbcsql' in driver_name) or ('sqlncli' in driver_name) or ('sqlsrv32.dll' == driver_name)
@@ -225,7 +224,7 @@ class SqlServerTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {}({}))".format(sqltype, colsize)
         else:
             sql = "create table t1(s %s)" % sqltype
         if colsize >= 2000 and (sqltype == 'nvarchar' or sqltype == 'varchar'):
@@ -280,7 +279,7 @@ class SqlServerTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {}({}))".format(sqltype, colsize)
         else:
             sql = "create table t1(s %s)" % sqltype
 
@@ -362,11 +361,11 @@ class SqlServerTestCase(unittest.TestCase):
 
     def test_chinese(self):
         v = '我的'
-        self.cursor.execute(u"SELECT N'我的' AS [Name]")
+        self.cursor.execute("SELECT N'我的' AS [Name]")
         row = self.cursor.fetchone()
         self.assertEqual(row[0], v)
 
-        self.cursor.execute(u"SELECT N'我的' AS [Name]")
+        self.cursor.execute("SELECT N'我的' AS [Name]")
         rows = self.cursor.fetchall()
         self.assertEqual(rows[0][0], v)
 
@@ -443,7 +442,7 @@ class SqlServerTestCase(unittest.TestCase):
     def _decimal(self, precision, scale, negative):
         # From test provided by planders (thanks!) in Issue 91
 
-        self.cursor.execute("create table t1(d decimal(%s, %s))" % (precision, scale))
+        self.cursor.execute("create table t1(d decimal({}, {}))".format(precision, scale))
 
         # Construct a decimal that uses the maximum precision and scale.
         decStr = '9' * (precision - scale)
@@ -475,7 +474,7 @@ class SqlServerTestCase(unittest.TestCase):
                        (38, 0,  True),
                        (38, 10, True),
                        (38, 38, True) ]:
-        locals()['test_decimal_%s_%s_%s' % (p, s, n and 'n' or 'p')] = _maketest(p, s, n)
+        locals()['test_decimal_{}_{}_{}'.format(p, s, n and 'n' or 'p')] = _maketest(p, s, n)
 
 
     def test_decimal_e(self):

--- a/tests/old/sqlitetests.py
+++ b/tests/old/sqlitetests.py
@@ -128,7 +128,7 @@ class SqliteTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {}({}))".format(sqltype, colsize)
         else:
             sql = "create table t1(s %s)" % sqltype
 
@@ -162,7 +162,7 @@ class SqliteTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {}({}))".format(sqltype, colsize)
         else:
             sql = "create table t1(s %s)" % sqltype
 

--- a/tests/sqlserver_test.py
+++ b/tests/sqlserver_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
 import os, uuid, re, sys
 from decimal import Decimal
@@ -1601,7 +1600,7 @@ def get_sqlserver_version(cursor: pyodbc.Cursor):
     return int(row.Character_Value.split('.', 1)[0])
 
 
-@lru_cache()
+@lru_cache
 def _generate_str(length, encoding=None):
     """
     Returns either a string or bytes, depending on whether encoding is provided,


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
