### PR TITLE
Handle bytes in the attrs_before parameter for pyodbc.connect()

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -124,6 +124,11 @@ static bool ApplyPreconnAttrs(HDBC hdbc, SQLINTEGER ikey, PyObject *value, char 
         ivalue = (SQLPOINTER)PyByteArray_AsString(value);
         vallen = SQL_IS_POINTER;
     }
+    else if (PyBytes_Check(value))
+    {
+        ivalue = PyBytes_AsString(value);
+        vallen = SQL_IS_POINTER;
+    }
     else if (PyUnicode_Check(value))
     {
         sqlchar.set(value, strencoding ? strencoding : "utf-16le");


### PR DESCRIPTION
An attempt to fix the segfault issue #1289 .

It looks like the code to handle byte values in the attrs_before parameter was lost in the v5 upgrade.  I've copied the original code back in.  The only difference is I've replaced the call to PyBytes_AS_STRING with the stable ABI compliant call to PyBytes_AsString.

@mkleehammer / @v-chojas / @gordthompson , I haven't been able to properly test this though, so do please check what I've done.