### PR TITLE
docs and pyodbc.pyi updates for pyodbc.odbcversion

### DIFF
--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -311,6 +311,7 @@ version: Final[str]  # not pep-0249
 # read-write (not pep-0249)
 lowercase: bool = False
 native_uuid: bool = False
+odbcversion: str = '3.X'
 pooling: bool = True
 
 

--- a/src/pyodbcmodule.cpp
+++ b/src/pyodbcmodule.cpp
@@ -67,13 +67,13 @@ static char module_doc[] =
     "\n"
     "paramstyle\n"
     "  The string constant 'qmark' to indicate parameters are identified using\n"
-    "  question marks."
+    "  question marks.\n"
     "\n"
     "odbcversion\n"
     "  The ODBC version number as a string, such as '3.X' for ODBC 3.X compatibility.\n"
     "  This is a global (HENV) setting, so it can only be modified before the first\n"
     "  connection is made. Use 3.8 if you are using unixodbc connection pooling and your\n"
-    "  drivers are all 3.8 compatible. The default is 3.X\n";
+    "  drivers are all 3.8 compatible. The default is '3.X'.";
 
 PyObject* Error;
 PyObject* Warning;


### PR DESCRIPTION
Add the pyodbc.odbcversion attribute to pyodbc.pyi, and tweak the newlines in the pyodbc docs for consistency.