### PR TITLE
Populate cursor "messages" attribute when fast_executemany=True

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -577,7 +577,7 @@ static bool PrepareResults(Cursor* cur, int cCols)
 }
 
 
-static int GetDiagRecs(Cursor* cur)
+int GetDiagRecs(Cursor* cur)
 {
     // Retrieves all diagnostic records from the cursor and assigns them to the "messages" attribute.
 

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -156,6 +156,8 @@ struct Cursor
     PyObject* messages;
 };
 
+int GetDiagRecs(Cursor* cur);
+
 void Cursor_init();
 
 Cursor* Cursor_New(Connection* cnxn);

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1674,6 +1674,11 @@ bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj)
             goto ErrorRet8;
         }
 
+        if (rc == SQL_SUCCESS_WITH_INFO)
+        {
+            GetDiagRecs(cur);
+        }
+
         // TODO: Refactor into ProcessDAEParams() ?
         while (rc == SQL_NEED_DATA)
         {


### PR DESCRIPTION
When fast_executemany is True, function ExecuteMulti() is called instead of execute().  ExecuteMulti() was not calling GetDiagRecs() to populate the cursor "messages" attribute.  This now happens.  I had to export GetDiagRecs() from cursor.cpp for that purpose.

Unit test added.  Also beefed up an existing unit test for unicode messages.

Fixes #1299 .