### PR TITLE
set statement attributes

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -976,6 +976,9 @@ static int Connection_settimeout(PyObject* self, PyObject* value, void* closure)
         return -1;
     }
 
+    // this same value is used for the cursor timeout
+    cnxn->timeout = timeout;
+
     SQLRETURN ret;
     Py_BEGIN_ALLOW_THREADS
     ret = SQLSetConnectAttr(cnxn->hdbc, SQL_ATTR_CONNECTION_TIMEOUT, (SQLPOINTER)(uintptr_t)timeout, SQL_IS_UINTEGER);
@@ -985,8 +988,6 @@ static int Connection_settimeout(PyObject* self, PyObject* value, void* closure)
         RaiseErrorFromHandle(cnxn, "SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
         return -1;
     }
-
-    cnxn->timeout = timeout;
 
     return 0;
 }


### PR DESCRIPTION
You can set connection-level attributes via `set_attr` but not cursor-level settings. Note that I haven't had time for tests here yet, but can put them together if adding this to the project makes sense.

- fix: set timeout before attempting connection timeout
- feat: adding set_attr to cursor
