### PR TITLE
Use SQLBindCol when possible

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -186,12 +186,12 @@ jobs:
         echo "*** pyodbc drivers"
         python -c "import pyodbc; print('\n'.join(sorted(pyodbc.drivers())))"
 
-    - name: Run PostgreSQL tests
+    - name: Run SQL Server 2022 tests
       env:
-        PYODBC_POSTGRESQL: "DRIVER={PostgreSQL Unicode};SERVER=localhost;PORT=5432;UID=postgres_user;PWD=postgres_pwd;DATABASE=test"
+        PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1403;UID=sa;PWD=StrongPassword2022;DATABASE=test;Encrypt=Optional"
       run: |
         cd "$GITHUB_WORKSPACE"
-        python -m pytest "./tests/postgresql_test.py"
+        python -m pytest "./tests/sqlserver_test.py"
 
     - name: Run MySQL tests
       env:
@@ -199,6 +199,13 @@ jobs:
       run: |
         cd "$GITHUB_WORKSPACE"
         python -m pytest "./tests/mysql_test.py"
+
+    - name: Run PostgreSQL tests
+      env:
+        PYODBC_POSTGRESQL: "DRIVER={PostgreSQL Unicode};SERVER=localhost;PORT=5432;UID=postgres_user;PWD=postgres_pwd;DATABASE=test"
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        python -m pytest "./tests/postgresql_test.py"
 
     - name: Run SQL Server 2017 tests
       env:
@@ -210,13 +217,6 @@ jobs:
     - name: Run SQL Server 2019 tests
       env:
         PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1402;UID=sa;PWD=StrongPassword2019;DATABASE=test;Encrypt=Optional"
-      run: |
-        cd "$GITHUB_WORKSPACE"
-        python -m pytest "./tests/sqlserver_test.py"
-
-    - name: Run SQL Server 2022 tests
-      env:
-        PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1403;UID=sa;PWD=StrongPassword2022;DATABASE=test;Encrypt=Optional"
       run: |
         cd "$GITHUB_WORKSPACE"
         python -m pytest "./tests/sqlserver_test.py"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,6 +1,6 @@
 name: Ubuntu build
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 jobs:
   run_tests:
@@ -186,12 +186,12 @@ jobs:
         echo "*** pyodbc drivers"
         python -c "import pyodbc; print('\n'.join(sorted(pyodbc.drivers())))"
 
-    - name: Run SQL Server 2022 tests
+    - name: Run PostgreSQL tests
       env:
-        PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1403;UID=sa;PWD=StrongPassword2022;DATABASE=test;Encrypt=Optional"
+        PYODBC_POSTGRESQL: "DRIVER={PostgreSQL Unicode};SERVER=localhost;PORT=5432;UID=postgres_user;PWD=postgres_pwd;DATABASE=test"
       run: |
         cd "$GITHUB_WORKSPACE"
-        python -m pytest "./tests/sqlserver_test.py"
+        python -m pytest "./tests/postgresql_test.py"
 
     - name: Run MySQL tests
       env:
@@ -199,13 +199,6 @@ jobs:
       run: |
         cd "$GITHUB_WORKSPACE"
         python -m pytest "./tests/mysql_test.py"
-
-    - name: Run PostgreSQL tests
-      env:
-        PYODBC_POSTGRESQL: "DRIVER={PostgreSQL Unicode};SERVER=localhost;PORT=5432;UID=postgres_user;PWD=postgres_pwd;DATABASE=test"
-      run: |
-        cd "$GITHUB_WORKSPACE"
-        python -m pytest "./tests/postgresql_test.py"
 
     - name: Run SQL Server 2017 tests
       env:
@@ -217,6 +210,13 @@ jobs:
     - name: Run SQL Server 2019 tests
       env:
         PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1402;UID=sa;PWD=StrongPassword2019;DATABASE=test;Encrypt=Optional"
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        python -m pytest "./tests/sqlserver_test.py"
+
+    - name: Run SQL Server 2022 tests
+      env:
+        PYODBC_SQLSERVER: "DRIVER={ODBC Driver 18 for SQL Server};SERVER=localhost,1403;UID=sa;PWD=StrongPassword2022;DATABASE=test;Encrypt=Optional"
       run: |
         cd "$GITHUB_WORKSPACE"
         python -m pytest "./tests/sqlserver_test.py"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,6 +1,6 @@
 name: Ubuntu build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run_tests:

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -702,6 +702,7 @@ static bool PrepareResults(Cursor* cur, int cCols)
         }
     }
 
+    cur->UseNativeUUID = UseNativeUUID();
     if (cur->cnxn->map_sqltype_to_converter)
     {
         cur->converted_types = PyDict_Keys(cur->cnxn->map_sqltype_to_converter);

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -591,6 +591,9 @@ static bool PrepareResults(Cursor* cur, int cCols)
         }
     }
 
+    Py_BEGIN_ALLOW_THREADS
+    SQLFreeStmt(cur->hstmt, SQL_UNBIND); // somehow columns can still be bound here
+    Py_END_ALLOW_THREADS;
     for (i = 0; i < cCols; i++)
     {
         if (!BindCol(cur, i))

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -340,17 +340,23 @@ static bool free_results(Cursor* self, int flags)
     {
         Py_ssize_t i, field_count = PyTuple_GET_SIZE(self->description);
 
-        for (i = 0; i < field_count; i++)
+        if (self->valueBufs)
         {
-            if (self->valueBufs[i])
+            for (i = 0; i < field_count; i++)
             {
-                PyMem_Free(self->valueBufs[i]);
+                if (self->valueBufs[i])
+                {
+                    PyMem_Free(self->valueBufs[i]);
+                }
             }
+            PyMem_Free(self->valueBufs);
+            self->valueBufs = 0;
         }
-        PyMem_Free(self->valueBufs);
-        self->valueBufs = 0;
-        PyMem_Free(self->cbFetchedBufs);
-        self->cbFetchedBufs = 0;
+        if (self->cbFetchedBufs)
+        {
+            PyMem_Free(self->cbFetchedBufs);
+            self->cbFetchedBufs = 0;
+        }
     }
 
     if (self->colinfos)

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -154,6 +154,10 @@ struct Cursor
     // The messages attribute described in the DB API 2.0 specification.
     // Contains a list of all non-data messages provided by the driver, retrieved using SQLGetDiagRec.
     PyObject* messages;
+
+    // Pointers to buffers used by SQLBindCol.
+    void** valueBufs;
+    SQLLEN* cbFetchedBufs;
 };
 
 void Cursor_init();

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -160,10 +160,8 @@ struct Cursor
     SQLLEN* cbFetchedBufs;
 
     // Track the configuration at the time of using SQLBindCol.
-    bool UseNativeUUID;
-    PyObject* converted_types;
-    // SQLSMALLINT* converted_types;
-    // int num_converted_types;
+    bool bound_native_uuid;
+    PyObject* bound_converted_types;
 };
 
 void Cursor_init();

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -158,6 +158,12 @@ struct Cursor
     // Pointers to buffers used by SQLBindCol.
     void** valueBufs;
     SQLLEN* cbFetchedBufs;
+
+    // Track the configuration at the time of using SQLBindCol.
+    bool UseNativeUUID;
+    PyObject* converted_types;
+    // SQLSMALLINT* converted_types;
+    // int num_converted_types;
 };
 
 void Cursor_init();

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -994,6 +994,7 @@ bool BindCol(Cursor* cur, Py_ssize_t iCol)
         return true;
     }
 
+    size = size * 4 + 100;
     cur->valueBufs[iCol] = PyMem_Malloc(size);
     if (!cur->valueBufs[iCol])
     {

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -944,7 +944,7 @@ bool BindCol(Cursor* cur, Py_ssize_t iCol)
         if (pinfo->column_size == 0 || pinfo->column_size > 1024*1024)
             return true;
         c_type = SQL_C_BINARY;
-        size = pinfo->column_size; // no null terminator
+        size = CharBufferSize(c_type, pinfo->column_size);
         break;
 
     case SQL_DECIMAL:

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -994,7 +994,6 @@ bool BindCol(Cursor* cur, Py_ssize_t iCol)
         return true;
     }
 
-    size = size * 4 + 100;
     cur->valueBufs[iCol] = PyMem_Malloc(size);
     if (!cur->valueBufs[iCol])
     {

--- a/src/getdata.h
+++ b/src/getdata.h
@@ -7,6 +7,7 @@ void GetData_init();
 PyObject* PythonTypeFromSqlType(Cursor* cur, SQLSMALLINT type);
 
 PyObject* GetData(Cursor* cur, Py_ssize_t iCol);
+bool BindCol(Cursor* cur, Py_ssize_t iCol);
 
 /**
  * If this sql type has a user-defined conversion, the index into the connection's `conv_funcs` array is returned.

--- a/tests/sqlserver_test.py
+++ b/tests/sqlserver_test.py
@@ -1249,6 +1249,47 @@ def test_output_conversion():
     assert value == '123.45'
 
 
+def test_rebind_columns():
+    """
+    Make sure SQLBindCol is called again with proper parameters if pyodbc
+    settings change between fetch calls.
+    """
+    def convert(value):
+        return value
+
+    cnxn = connect()
+    cursor = cnxn.cursor()
+
+    uidstr = 'CB4BB7F2-3AD9-4ED7-ABB8-7C704D75335C'
+    uid = uuid.UUID(uidstr)
+    uidbytes = b'\xf2\xb7K\xcb\xd9:\xd7N\xab\xb8|pMu3\\'
+
+    cursor.execute("drop table if exists t1")
+    cursor.execute("create table t1(g uniqueidentifier)")
+    for i in range(4):
+        cursor.execute(f"insert into t1 values (?)", (uid,))
+
+    cursor.execute("select g from t1")
+
+    pyodbc.native_uuid = False
+    v, = cursor.fetchone()
+    assert v == uidstr
+
+    cnxn.add_output_converter(pyodbc.SQL_GUID, convert)
+    v, = cursor.fetchone()
+    assert v == uidbytes
+    cnxn.remove_output_converter(pyodbc.SQL_GUID)
+
+    pyodbc.native_uuid = True
+    v, = cursor.fetchone()
+    assert v == uid
+
+    pyodbc.native_uuid = False
+    v, = cursor.fetchone()
+    assert v == uidstr
+    pyodbc.native_uuid = True
+
+
 def test_too_large(cursor: pyodbc.Cursor):
     """Ensure error raised if insert fails due to truncation"""
     value = 'x' * 1000


### PR DESCRIPTION
When all columns can be bound and the bandwidth is good enough, this should provide a decent performance improvement, as SQLGetData seems to use a bunch of CPU power. I didn't do extensive benchmarks, but in a small scale cloud web app connected to a decently powerful Azure SQL DB (same region), I got up to a 50% lower execution time on a cursor.execute(...).fetchall() call. Probably 30% is more realistic.

Unfortunately the API allows changing native_uuid and output converters between fetch calls, so the code checks for changes and rebinds when necessary. I've added a test for it.

Some config variables that could be added are a cap on total memory that can be allocated for binding and the threshold at which we use SQLGetData for variable length data. But since only one row is bound this might be unnecessary.