### PR TITLE
Implemented support for the SQL Server sql_variant data type

### DIFF
--- a/src/dbspecific.h
+++ b/src/dbspecific.h
@@ -11,6 +11,7 @@
 // SQL Server
 
 
+#define SQL_SS_VARIANT -150     // SQL Server 2008 SQL_VARIANT type
 #define SQL_SS_XML -152         // SQL Server 2005 XML type
 #define SQL_DB2_DECFLOAT -360   // IBM DB/2 DECFLOAT type
 #define SQL_DB2_XML -370        // IBM DB/2 XML type

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -535,30 +535,30 @@ static PyObject* GetDataTimestamp(Cursor* cur, Py_ssize_t iCol)
 
     switch (cur->colinfos[iCol].sql_type)
     {
-		case SQL_TYPE_TIME:
-		{
-			int micros = (int)(value.fraction / 1000); // nanos --> micros
-			return PyTime_FromTime(value.hour, value.minute, value.second, micros);
-		}
+        case SQL_TYPE_TIME:
+        {
+            int micros = (int)(value.fraction / 1000); // nanos --> micros
+            return PyTime_FromTime(value.hour, value.minute, value.second, micros);
+        }
 
-		case SQL_TYPE_DATE:
+        case SQL_TYPE_DATE:
         case SQL_DATE:
-			return PyDate_FromDate(value.year, value.month, value.day);
+            return PyDate_FromDate(value.year, value.month, value.day);
 
-		case SQL_TYPE_TIMESTAMP:
+        case SQL_TYPE_TIMESTAMP:
         case SQL_TIMESTAMP:
-		{
-			if (value.year < 1)
-			{
-				value.year = 1;
-			}
-			else if (value.year > 9999)
-			{
-				value.year = 9999;
-			}
-		}
+        {
+            if (value.year < 1)
+            {
+                value.year = 1;
+            }
+            else if (value.year > 9999)
+            {
+                value.year = 9999;
+            }
+        }
     }
-	
+
 
     int micros = (int)(value.fraction / 1000); // nanos --> micros
 
@@ -779,7 +779,7 @@ PyObject *GetData_SqlVariant(Cursor *cur, Py_ssize_t iCol) {
     // the ODBC driver read the sql_variant header which contains the underlying data type
     pBuff = 0;
     indicator = 0;
-    retcode = SQLGetData(cur->hstmt, static_cast<SQLSMALLINT>(iCol + 1), SQL_C_BINARY,   
+    retcode = SQLGetData(cur->hstmt, static_cast<SQLSMALLINT>(iCol + 1), SQL_C_BINARY,
                                     &pBuff, 0, &indicator);
     if (!SQL_SUCCEEDED(retcode))
         return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);

--- a/src/pyodbc.h
+++ b/src/pyodbc.h
@@ -76,6 +76,10 @@ typedef unsigned long long UINT64;
 #define SQL_CA_SS_CATALOG_NAME 1225
 #endif
 
+#ifndef SQL_CA_SS_VARIANT_TYPE
+#define SQL_CA_SS_VARIANT_TYPE 1215
+#endif
+
 inline bool IsSet(DWORD grf, DWORD flags)
 {
     return (grf & flags) == flags;

--- a/src/pyodbc.h
+++ b/src/pyodbc.h
@@ -121,7 +121,7 @@ inline void DebugTrace(const char* szFmt, ...) { UNUSED(szFmt); }
 
 // issue #880: entry missing from iODBC sqltypes.h
 #ifndef BYTE
-  typedef unsigned char		BYTE;
+  typedef unsigned char BYTE;
 #endif
 bool PyMem_Realloc(BYTE** pp, size_t newlen);
 // A wrapper around realloc with a safer interface.  If it is successful, *pp is updated to the


### PR DESCRIPTION
This commit adds support for decoding the SQL Server `sql_variant` data type.

Attempting to read records containing `sql_variant` columns in the current version of `pyodbc` (5.1.0) results in the following exception:

```
pyodbc.ProgrammingError: ('ODBC SQL type -150 is not yet supported.  column-index=0  type=-150', 'HY106')
```

As mentioned in #307, it is not trivial to write a custom output converter for `sql_variant` as the bytes returned by SQL Server give no indication as to the underlying data type of each value.

This commit adds a `GetData_SqlVariant()` method which retrieves the underlying data type [per the Microsoft documentation](https://learn.microsoft.com/en-us/sql/relational-databases/native-client-odbc-results/mapping-data-types-odbc?view=sql-server-ver15) using `SQLColAttribute()`:

```cpp
// Call SQLGetData on the current column with a data length of 0. According to MS, this makes
// the ODBC driver read the sql_variant header which contains the underlying data type
pBuff = 0;
indicator = 0;
retcode = SQLGetData(cur->hstmt, static_cast<SQLSMALLINT>(iCol + 1), SQL_C_BINARY,   
                                &pBuff, 0, &indicator);
if (!SQL_SUCCEEDED(retcode))
    return RaiseErrorFromHandle(cur->cnxn, "SQLGetData", cur->cnxn->hdbc, cur->hstmt);

// Get the SQL_CA_SS_VARIANT_TYPE field for the column which will contain the underlying data type
variantType = 0;
retcode = SQLColAttribute(cur->hstmt, iCol + 1, SQL_CA_SS_VARIANT_TYPE, NULL, 0, NULL, &variantType);
if (!SQL_SUCCEEDED(retcode))
    return RaiseErrorFromHandle(cur->cnxn, "SQLColAttribute", cur->cnxn->hdbc, cur->hstmt);
```

This underlying data type is then patched into the `ColumnInfo` struct for the current column and `GetData()` is invoked using this new type:

```cpp
// Replace the original SQL_VARIANT data type with the underlying data type then call GetData() again
cur->colinfos[iCol].sql_type = static_cast<SQLSMALLINT>(variantType);
return GetData(cur, iCol);
```

The `sql_variant` type is used by a number of system functions and views and this commit adds support for reading them:

```python
import pyodbc

connection = pyodbc.connect(...)
print(
    connection.execute(
        """
        SELECT
            SERVERPROPERTY('MachineName'),
            SERVERPROPERTY('InstanceName'),
            SERVERPROPERTY('Edition'),
            SERVERPROPERTY('ProductVersion'),
            SERVERPROPERTY('ProductLevel');
        """
    ).fetchone()
)

# ('acfd83beaa19', '', 'Developer Edition (64-bit)', '16.0.4003.1', 'RTM')
```