### PR TITLE
Drop support for EOL Python 3.8

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     services:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,8 +56,6 @@ environment:
     - PYTHON_HOME: "C:\\Python310"
     - PYTHON_HOME: "C:\\Python39-x64"
     - PYTHON_HOME: "C:\\Python39"
-    - PYTHON_HOME: "C:\\Python38-x64"
-    - PYTHON_HOME: "C:\\Python38"
 
 # ref: https://www.appveyor.com/docs/services-databases/
 init:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pyodbc"
 version = "5.2.0"
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 # This is used by the GitHub action that builds release artifacts using cibuildwheel.
 # cibuildwheel reads this directly:
 #
@@ -10,8 +10,7 @@ requires-python = ">=3.8"
 
 description = "DB API module for ODBC"
 readme = "README.md"
-# change license to just "MIT-0" when py3.8 is dropped
-license = {text = "MIT-0"}
+license = "MIT-0"
 
 authors = [{name = "Michael Kleehammer", email="michael@kleehammer.com"}]
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main():
         package_dir={'': 'src'},
         package_data={'': ['pyodbc.pyi']},  # places pyodbc.pyi alongside pyodbc.{platform}.{pyd|so} in site-packages
         license='MIT-0',
-        python_requires='>=3.8',
+        python_requires='>=3.9',
         classifiers=['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',
                      'Intended Audience :: System Administrators',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,8 @@ def _add_to_path():
     Prepends the build directory to the path so that newly built pyodbc libraries are
     used, allowing it to be tested without pip-installing it.
     """
-    # look for the suffixes used in the build filenames, e.g. ".cp38-win_amd64.pyd",
-    # ".cpython-38-darwin.so", ".cpython-38-x86_64-linux-gnu.so", etc.
+    # look for the suffixes used in the build filenames, e.g. ".cp313-win_amd64.pyd",
+    # ".cpython-313-darwin.so", ".cpython-313-x86_64-linux-gnu.so", etc.
     library_exts = [ext for ext in importlib.machinery.EXTENSION_SUFFIXES if ext != '.pyd']
     # generate the name of the pyodbc build file(s)
     library_names = [f'pyodbc{ext}' for ext in library_exts]

--- a/tox.ini
+++ b/tox.ini
@@ -19,14 +19,14 @@
 # Naturally, test databases must be up and available before running the tests.
 # Run the unit tests against multiple versions of Python by calling "tox" from
 # this directory.  To run tests against only one version of Python, call, for
-# example, "tox -e py37".
+# example, "tox -e py313".
 # To run tests against only certain databases, comment out the relevant "pytest"
 # commands below.
-# To override the pytest default parameters, use "--", e.g. "tox -e py37 -- -rA".
+# To override the pytest default parameters, use "--", e.g. "tox -e py313 -- -rA".
 
 [tox]
 skipsdist = true
-env_list = py{37,38,39,310,311}
+env_list = py{39,310,311,312,313}
 
 [testenv]
 description = Run the pyodbc unit tests


### PR DESCRIPTION
Python 3.8 became end of life on 2024-10-07 according to https://devguide.python.org/versions/

Inspired by the previous PR that dropped support for Python 3.7 https://github.com/mkleehammer/pyodbc/pull/1275