### PR TITLE
Allow fetch of DB2 BLOB

### DIFF
--- a/src/dbspecific.h
+++ b/src/dbspecific.h
@@ -16,6 +16,7 @@
 #define SQL_DB2_DECFLOAT -360   // IBM DB/2 DECFLOAT type
 #define SQL_DB2_XML -370        // IBM DB/2 XML type
 #define SQL_SS_TIME2 -154       // SQL Server 2008 time type
+#define SQL_DB2_BLOB -98        // IBM DB/2 BLOB type
 
 struct SQL_SS_TIME2_STRUCT
 {

--- a/src/getdata.cpp
+++ b/src/getdata.cpp
@@ -725,6 +725,7 @@ PyObject* GetData(Cursor* cur, Py_ssize_t iCol)
     case SQL_BINARY:
     case SQL_VARBINARY:
     case SQL_LONGVARBINARY:
+    case SQL_DB2_BLOB:
         return GetBinary(cur, iCol);
 
     case SQL_DECIMAL:


### PR DESCRIPTION
There's no pipeline scaffolding for DB2 tests. I have tested locally with DB2 v11.5.8.0, IBM ODBC driver 11.5.0 linux 64, Python 3.12.3.

Closes #1411