### PR TITLE
Add flag for buggy SQLGetDiagRecW driver behavior

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -250,6 +250,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, long timeou
     cnxn->maxwrite     = 0;
     cnxn->timeout      = 0;
     cnxn->map_sqltype_to_converter = 0;
+    cnxn->compat_diagrec_byte_length = false;
 
     cnxn->attrs_before = attrs_before_o.Detach();
 
@@ -991,6 +992,22 @@ static int Connection_settimeout(PyObject* self, PyObject* value, void* closure)
     return 0;
 }
 
+static PyObject* Connection_getcompat_diagrec_byte_length(PyObject* self, void* closure)
+{
+    return PyBool_FromLong(((Connection*)self)->compat_diagrec_byte_length);
+}
+
+static int Connection_setcompat_diagrec_byte_length(PyObject* self, PyObject* value, void* closure)
+{
+    if (!PyBool_Check(value))
+    {
+        PyErr_SetString(PyExc_TypeError, "compat_diagrec_byte_length must be a bool");
+        return -1;
+    }
+    ((Connection*)self)->compat_diagrec_byte_length = (value == Py_True);
+    return 0;
+}
+
 static bool _remove_converter(PyObject* self, SQLSMALLINT sqltype)
 {
     Connection* cnxn = (Connection*)self;
@@ -1394,6 +1411,8 @@ static PyGetSetDef Connection_getseters[] = {
     { "timeout", Connection_gettimeout, Connection_settimeout,
       "The timeout in seconds, zero means no timeout.", 0 },
     { "maxwrite", Connection_getmaxwrite, Connection_setmaxwrite, "The maximum bytes to write before using SQLPutData.", 0 },
+    { "compat_diagrec_byte_length", Connection_getcompat_diagrec_byte_length, Connection_setcompat_diagrec_byte_length,
+      "If True, the driver reports byte length instead of character length in SQLGetDiagRecW().", 0 },
     { 0 }
 };
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -87,6 +87,11 @@ struct Connection
 
     bool need_long_data_len;
 
+    // Flag for drivers which report the number of bytes in the returned diagnostic message
+    // from a call to SQLGetDiagRecW() rather than the number of characters, as required
+    // by ODBC. See https://github.com/mkleehammer/pyodbc/issues/489.
+    bool compat_diagrec_byte_length;
+
     PyObject* map_sqltype_to_converter;
     // If converters are defined, this will be a dictionary mapping from the SQLTYPE cast to an
     // int (because types can be negative) to the converter function.

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -602,6 +602,9 @@ int GetDiagRecs(Cursor* cur)
     if (!msg_list)
         return 0;
 
+    // See https://github.com/mkleehammer/pyodbc/issues/489
+    bool text_length_in_bytes = cur->cnxn->compat_diagrec_byte_length;
+
     for (;;)
     {
         cSQLState[0]    = 0;
@@ -617,6 +620,10 @@ int GetDiagRecs(Cursor* cur)
         Py_END_ALLOW_THREADS
         if (!SQL_SUCCEEDED(ret))
             break;
+
+        // Make sure the text length counts characters, not bytes.
+        if (text_length_in_bytes)
+            iTextLength /= sizeof(uint16_t);
 
         // If needed, allocate a bigger error message buffer and retry.
         if (iTextLength > iMessageLen - 1) {
@@ -634,6 +641,8 @@ int GetDiagRecs(Cursor* cur)
             Py_END_ALLOW_THREADS
             if (!SQL_SUCCEEDED(ret))
                 break;
+            if (text_length_in_bytes)
+                iTextLength /= sizeof(uint16_t);
         }
 
         cSQLState[5] = 0;  // Not always NULL terminated (MS Access)
@@ -1134,7 +1143,7 @@ static PyObject* Cursor_setinputsizes(PyObject* self, PyObject* sizes)
         PyErr_SetString(ProgrammingError, "Invalid cursor object.");
         return 0;
     }
-    
+
     Cursor *cur = (Cursor*)self;
     if (Py_None == sizes)
     {

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -234,6 +234,9 @@ PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc
 
     Object msg;
 
+    // See https://github.com/mkleehammer/pyodbc/issues/489
+    bool text_length_in_bytes = conn->compat_diagrec_byte_length;
+
     for (;;)
     {
         szMsg[0]     = 0;
@@ -248,6 +251,10 @@ PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc
         if (!SQL_SUCCEEDED(ret))
             break;
 
+        // Make sure the text length counts characters, not bytes.
+        if (text_length_in_bytes)
+            cchMsg /= sizeof(uint16_t);
+
         // If needed, allocate a bigger error message buffer and retry.
         if (cchMsg > msgLen - 1) {
             msgLen = cchMsg + 1;
@@ -261,6 +268,8 @@ PyObject* GetErrorFromHandle(Connection *conn, const char* szFunction, HDBC hdbc
             Py_END_ALLOW_THREADS
             if (!SQL_SUCCEEDED(ret))
                 break;
+            if (text_length_in_bytes)
+                cchMsg /= sizeof(uint16_t);
         }
 
         // Not always NULL terminated (MS Access)

--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -356,6 +356,18 @@ class Connection:
         ...
 
     @property
+    def compat_diagrec_byte_length(self) -> bool:
+        """Set to True if the driver incorrectly reports byte length instead of
+        character length for diagnostic messages.
+
+        See https://github.com/mkleehammer/pyodbc/issues/489."""
+        ...
+
+    @compat_diagrec_byte_length.setter
+    def compat_diagrec_byte_length(self, value: bool) -> None:
+        ...
+
+    @property
     def maxwrite(self) -> int:
         """The maximum bytes to write before using SQLPutData, default is zero for no maximum."""
         ...


### PR DESCRIPTION
When the connection property compat_diagrec_byte_length is set to `True` we know that the driver reports the diagnostic message size in bytes (instead of characters as called for by ODBC). This works around a bug in Oracle's ODBC driver.

Fixes #489