### PR TITLE
Allow setting of connection string attributes

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -351,25 +351,44 @@ static char set_attr_doc[] =
     "attr_id\n"
     "  The attribute id (integer) to set.  These are ODBC or driver constants.\n\n"
     "value\n"
-    "  An integer value.\n\n"
-    "At this time, only integer values are supported and are always passed as SQLUINTEGER.";
+    "  An integer or string value.";
 
 static PyObject* Connection_set_attr(PyObject* self, PyObject* args)
 {
     int id;
-    int value;
-    if (!PyArg_ParseTuple(args, "ii", &id, &value))
+    PyObject* value;
+    if (!PyArg_ParseTuple(args, "iO", &id, &value))
         return 0;
 
     Connection* cnxn = (Connection*)self;
 
     SQLRETURN ret;
-    Py_BEGIN_ALLOW_THREADS
-    ret = SQLSetConnectAttr(cnxn->hdbc, id, (SQLPOINTER)(intptr_t)value, SQL_IS_INTEGER);
-    Py_END_ALLOW_THREADS
+    SQLWChar sqlchar;  // declared here so buffer stays alive across the call
+
+    if (PyLong_Check(value))
+    {
+        long ival = PyLong_AsLong(value);
+        Py_BEGIN_ALLOW_THREADS
+        ret = SQLSetConnectAttrW(cnxn->hdbc, id, (SQLPOINTER)(intptr_t)ival, SQL_IS_INTEGER);
+        Py_END_ALLOW_THREADS
+    }
+    else if (PyUnicode_Check(value))
+    {
+        sqlchar.set(value, "utf-16le");
+        Py_BEGIN_ALLOW_THREADS
+        ret = SQLSetConnectAttrW(cnxn->hdbc, id, sqlchar.get(), SQL_NTS);
+        Py_END_ALLOW_THREADS
+    }
+    else
+    {
+        PyErr_Format(PyExc_TypeError, "set_attr value must be a string or integer, not '%s'",
+                     Py_TYPE(value)->tp_name);
+        return 0;
+    }
 
     if (!SQL_SUCCEEDED(ret))
         return RaiseErrorFromHandle(cnxn, "SQLSetConnectAttr", cnxn->hdbc, SQL_NULL_HANDLE);
+
     Py_RETURN_NONE;
 }
 

--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -427,7 +427,7 @@ class Connection:
         """
         ...
 
-    def set_attr(self, attr_id: int, value: int, /) -> None:
+    def set_attr(self, attr_id: int, value: int | str, /) -> None:
         """Set an attribute on the connection, via SQLSetConnectAttr.
 
         Args:

--- a/tests/sqlserver_test.py
+++ b/tests/sqlserver_test.py
@@ -1700,3 +1700,15 @@ def _generate_str(length, encoding=None):
     v = v[:length]
 
     return v
+
+
+def test_set_string_attr(cursor: pyodbc.Cursor):
+    """Confirm that set_attr() now accepts string values.
+
+    See https://github.com/mkleehammer/pyodbc/issues/505
+    """
+    original_db = cursor.execute("SELECT db_name()").fetchval()
+    assert original_db != "master"
+    cursor.connection.set_attr(pyodbc.SQL_ATTR_CURRENT_CATALOG, "master")
+    new_db = cursor.execute("SELECT db_name()").fetchval()
+    assert new_db == "master"


### PR DESCRIPTION
I don't see any evidence that the regression tests are run with the ability to create a database, so I can't write a test that verifies the behavior requested by the OP (though I have tested locally to confirm that it works as expected with a DBMS which supports switching the current database for an existing connection; see ticket).

Fixes #505