### PR TITLE
Remove incorrect check when unpickling Row

### DIFF
--- a/src/row.cpp
+++ b/src/row.cpp
@@ -107,7 +107,7 @@ static PyObject* new_check(PyObject* args)
 
     Py_ssize_t cols = PyTuple_GET_SIZE(desc);
 
-    if (PyDict_Size(map) != cols || PyTuple_GET_SIZE(args) - 2 != cols)
+    if (PyTuple_GET_SIZE(args) - 2 != cols)
         return 0;
 
     PyObject** apValues = (PyObject**)PyMem_Malloc(sizeof(PyObject*) * cols);

--- a/tests/sqlite_test.py
+++ b/tests/sqlite_test.py
@@ -726,3 +726,9 @@ def test_pickling(cnxn: pyodbc.Connection):
     pickled_rows = pickle.dumps(original_rows)
     unpickled_rows = pickle.loads(pickled_rows)
     assert unpickled_rows == original_rows
+
+    # pickling works for rows with duplicate column names
+    original_rows = crsr.execute("select n, s, s from t1").fetchall()
+    pickled_rows = pickle.dumps(original_rows)
+    unpickled_rows = pickle.loads(pickled_rows)
+    assert unpickled_rows == original_rows


### PR DESCRIPTION
It is not always true that the number of values in a Row matches the size of the Row's value dictionary, because the dictionary can only store a single entry for a given column name.

Fixes #649