### PR TITLE
Implement PEP 675

### DIFF
--- a/src/pyodbc.pyi
+++ b/src/pyodbc.pyi
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from typing import Any, Callable, Final, Union
+from typing_extensions import LiteralString
 
 
 # SQLSetConnectAttr attributes
@@ -484,7 +485,7 @@ class Connection:
         """
         ...
 
-    def execute(self, sql: str, *params: Any) -> Cursor:
+    def execute(self, sql: LiteralString, *params: Any) -> Cursor:
         """A convenience function for running queries directly from a Connection object.
         Creates a new cursor, runs the SQL query, and returns the new cursor.
 
@@ -619,7 +620,7 @@ class Cursor:
         """Not supported."""
         ...
 
-    def execute(self, sql: str, *params: Any) -> Cursor:
+    def execute(self, sql: LiteralString, *params: Any) -> Cursor:
         """Run a SQL query and return the cursor.  If the query returns multiple result
         sets (generally because the SQL query contained multiple statements), retrieve
         them by making multiple calls to the nextset() function.
@@ -633,7 +634,7 @@ class Cursor:
         """
         ...
 
-    def executemany(self, sql: str, params: Union[Sequence, Iterator, Generator], /) -> None:
+    def executemany(self, sql: LiteralString, params: Union[Sequence, Iterator, Generator], /) -> None:
         """Run the SQL query against an iterable of parameters.  The behavior of this
         function depends heavily on the setting of the fast_executemany cursor property.
         See the Wiki for details.


### PR DESCRIPTION
I hesitated with this one, after reading the [discussion in a similar ticket](https://github.com/sqlalchemy/sqlalchemy/issues/10255) for the SQLAlchemy project. But then I saw that @mkleehammer has tagged this for release with the [6.0 Stable ABI](https://github.com/mkleehammer/pyodbc/milestone/4) milestone, so here's the PR.

I took a fairly conservative approach, modifying the obvious SQL execution methods where the bulk of the vulnerabilities tend to bite. Some of the (less-frequently used) catalog methods could in theory also be vulnerable if a driver were to try and collect the requested information using hand-rolled SQL strings instead of parameterized queries (or the builtin stored procedures most back ends provide for this purpose), but that's much further into edge-case territory, and I didn't want to go there without some encouragement from the core team to do so (and I thought it best to keep this simple in case it's decided we don't want to support the PEP after all).

As a side note, if you want to test, you should be aware that [mypy](https://www.mypy-lang.org/) doesn't yet know what to do with `LiteralString`. You'll want to use the newer [pyright](https://github.com/microsoft/pyright) instead.

Closes #1166