### PR TITLE
Add an optional SQL Server BCP fast path for fast_executemany

### DIFF
--- a/src/bcp_support.cpp
+++ b/src/bcp_support.cpp
@@ -1,0 +1,939 @@
+#include "pyodbc.h"
+#include "wrapper.h"
+#include "textenc.h"
+#include "connection.h"
+#include "bcp_support.h"
+
+
+// Diagnostic logging toggle, controlled by the PYODBC_BCP_DEBUG environment
+// variable. Evaluated once and cached. When enabled, driver loading emits
+// progress lines to stderr to help diagnose why BCP is unavailable.
+static int bcp_debug_enabled(void) {
+    static int cached = -1;
+    if (cached == -1) {
+        const char* v = getenv("PYODBC_BCP_DEBUG");
+        cached = (v && v[0] && !(v[0] == '0' && v[1] == '\0')) ? 1 : 0;
+    }
+    return cached;
+}
+
+static bool get_driver_name(HDBC hdbc, char* buf, SQLSMALLINT buflen) {
+    SQLSMALLINT outlen = 0;
+    if (SQLGetInfo(hdbc, SQL_DRIVER_NAME, (SQLPOINTER)buf, buflen, &outlen) != SQL_SUCCESS)
+        return false;
+    buf[buflen-1] = '\0';
+    return true;
+}
+
+#ifdef _WIN32
+static FARPROC sym(HMODULE m, const char* n) {
+    FARPROC p = GetProcAddress(m, n);
+    if (!p) {
+        // Some builds decorate stdcall exports; can try common decorations as a fallback:
+        // e.g., "_bcp_initA@20"
+        // You can generate decorated names if needed, but "bcp_initA" works.
+    }
+    return p;
+}
+#else
+static void* sym(void* m, const char* n) {
+    return dlsym(m, n);
+}
+#endif
+
+template <class TMod, class TFn>
+static bool fill_sym(TMod mod, const char* a, const char* b, TFn& out) {
+#ifdef _WIN32
+    out = reinterpret_cast<TFn>(sym(mod, a));
+    if (!out && b) out = reinterpret_cast<TFn>(sym(mod, b));
+#else
+    out = reinterpret_cast<TFn>(sym(mod, a));
+    if (!out && b) out = reinterpret_cast<TFn>(sym(mod, b));
+#endif
+    return out != nullptr;
+}
+
+#define BCPLOAD_DBG(...) do { if (bcp_debug_enabled()) { fprintf(stderr, "[bcp] " __VA_ARGS__); fflush(stderr); } } while (0)
+
+#ifdef __linux__
+// SQLGetInfo(SQL_DRIVER_NAME) returns a bare versioned soname (e.g.
+// "libmsodbcsql-18.5.so.1.1") that dlopen() can't resolve unless its directory
+// is on the loader path. The driver manager has, however, already mapped the
+// real library into this process, so its absolute path is available in
+// /proc/self/maps. Find the mapping whose basename matches the soname (or, as a
+// looser fallback, that looks like the msodbcsql driver) and return its path.
+static bool find_driver_path_in_maps(const char* soname, char* out, size_t outcap) {
+    FILE* f = fopen("/proc/self/maps", "r");
+    if (!f) return false;
+    char line[8192];
+    bool found = false;
+    while (fgets(line, sizeof(line), f)) {
+        char* path = strchr(line, '/');
+        if (!path) continue;
+        size_t len = strlen(path);
+        while (len && (path[len-1] == '\n' || path[len-1] == '\r')) path[--len] = '\0';
+        const char* base = strrchr(path, '/');
+        base = base ? base + 1 : path;
+        // Prefer an exact soname match; otherwise accept a library whose basename
+        // *starts with* "libmsodbcsql" (not merely contains it, to avoid matching
+        // an unrelated mapping).
+        if ((soname && soname[0] && strcmp(base, soname) == 0) ||
+            strncmp(base, "libmsodbcsql", 12) == 0) {
+            strncpy(out, path, outcap - 1);
+            out[outcap - 1] = '\0';
+            found = true;
+            break;
+        }
+    }
+    fclose(f);
+    return found;
+}
+#endif
+
+bool BcpLoadFromDriver(HDBC hdbc, BcpProcs& out) {
+    out = BcpProcs{}; // reset
+
+    char drv[256] = {0};
+    if (!get_driver_name(hdbc, drv, sizeof(drv))) {
+        BCPLOAD_DBG("load: SQLGetInfo(SQL_DRIVER_NAME) failed\n");
+        return false;
+    }
+    BCPLOAD_DBG("load: driver name = '%s'\n", drv);
+
+#ifdef _WIN32
+    HMODULE mod = GetModuleHandleA(drv);    // Driver name is typically "msodbcsql17.dll" or "msodbcsql18.dll"
+    if (!mod) mod = LoadLibraryA(drv);      // Try again in case the driver name is not a full path
+    if (!mod) { BCPLOAD_DBG("load: could not get/load module '%s'\n", drv); return false; }
+
+    if (!fill_sym(mod, "bcp_initA",   "bcp_init",    out.bcp_initA))  { BCPLOAD_DBG("load: missing bcp_initA\n");   return false; }
+    if (!fill_sym(mod, "bcp_bind",    nullptr,       out.bcp_bind))   { BCPLOAD_DBG("load: missing bcp_bind\n");    return false; }
+    if (!fill_sym(mod, "bcp_collen",  nullptr,       out.bcp_collen)) { BCPLOAD_DBG("load: missing bcp_collen\n");  return false; }
+    if (!fill_sym(mod, "bcp_colptr",  nullptr,       out.bcp_colptr)) { BCPLOAD_DBG("load: missing bcp_colptr\n");  return false; }
+    if (!fill_sym(mod, "bcp_sendrow", nullptr,       out.bcp_sendrow)){ BCPLOAD_DBG("load: missing bcp_sendrow\n"); return false; }
+    fill_sym(mod,     "bcp_batch",    nullptr,       out.bcp_batch);  // optional
+    if (!fill_sym(mod,"bcp_done",     nullptr,       out.bcp_done))   { BCPLOAD_DBG("load: missing bcp_done\n");    return false; }
+    fill_sym(mod,     "bcp_control",  nullptr,       out.bcp_control);// optional
+#else
+    // Helper: load the BCP symbols from a given handle (handle may be
+    // RTLD_DEFAULT, which is NULL on glibc, so we track success separately).
+    auto load_syms = [&](void* m) -> bool {
+        out = BcpProcs{};
+        if (!fill_sym(m, "bcp_initA",   "bcp_init",  out.bcp_initA))  { BCPLOAD_DBG("load:   missing bcp_initA/bcp_init\n"); return false; }
+        if (!fill_sym(m, "bcp_bind",    nullptr,     out.bcp_bind))   { BCPLOAD_DBG("load:   missing bcp_bind\n");    return false; }
+        if (!fill_sym(m, "bcp_collen",  nullptr,     out.bcp_collen)) { BCPLOAD_DBG("load:   missing bcp_collen\n");  return false; }
+        if (!fill_sym(m, "bcp_colptr",  nullptr,     out.bcp_colptr)) { BCPLOAD_DBG("load:   missing bcp_colptr\n");  return false; }
+        if (!fill_sym(m, "bcp_sendrow", nullptr,     out.bcp_sendrow)){ BCPLOAD_DBG("load:   missing bcp_sendrow\n"); return false; }
+        fill_sym(m,     "bcp_batch",    nullptr,     out.bcp_batch);   // optional
+        if (!fill_sym(m, "bcp_done",    nullptr,     out.bcp_done))   { BCPLOAD_DBG("load:   missing bcp_done\n");    return false; }
+        fill_sym(m,     "bcp_control",  nullptr,     out.bcp_control); // optional
+        return true;
+    };
+
+    bool loaded = false;
+
+    // 1) dlopen the driver name reported by the driver manager (often a full
+    //    path on unixODBC). Use RTLD_GLOBAL so symbols stay resolvable.
+    void* mod = dlopen(drv, RTLD_NOW|RTLD_GLOBAL);
+    if (mod) { BCPLOAD_DBG("load: dlopen('%s') ok\n", drv); loaded = load_syms(mod); }
+    else     { BCPLOAD_DBG("load: dlopen('%s') failed: %s\n", drv, dlerror()); }
+
+    // 2) The driver manager already has the driver loaded in-process; try the
+    //    global symbol table (RTLD_DEFAULT) before giving up.
+    if (!loaded) {
+        BCPLOAD_DBG("load: trying RTLD_DEFAULT (in-process symbols)\n");
+        loaded = load_syms(RTLD_DEFAULT);
+    }
+
+#ifdef __linux__
+    // 3) Resolve the driver's absolute path from /proc/self/maps and dlopen it
+    //    with RTLD_GLOBAL. Version- and location-agnostic.
+    if (!loaded) {
+        char fullpath[4096] = {0};
+        if (find_driver_path_in_maps(drv, fullpath, sizeof(fullpath))) {
+            BCPLOAD_DBG("load: driver mapped at '%s'\n", fullpath);
+            void* h = dlopen(fullpath, RTLD_NOW|RTLD_GLOBAL);
+            if (h) loaded = load_syms(h);
+            else   BCPLOAD_DBG("load: dlopen('%s') failed: %s\n", fullpath, dlerror());
+        } else {
+            BCPLOAD_DBG("load: driver not found in /proc/self/maps\n");
+        }
+    }
+#endif
+
+    // 4) Last resort: probe well-known msodbcsql install locations.
+    if (!loaded) {
+        static const char* candidates[] = {
+            "libmsodbcsql-18.so", "libmsodbcsql-17.so", "libmsodbcsql.so",
+            "/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.so",
+            "/opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.so",
+        };
+        for (size_t i = 0; i < sizeof(candidates)/sizeof(candidates[0]) && !loaded; ++i) {
+            void* h = dlopen(candidates[i], RTLD_NOW|RTLD_GLOBAL);
+            if (h) { BCPLOAD_DBG("load: opened fallback '%s'\n", candidates[i]); loaded = load_syms(h); }
+        }
+    }
+
+    if (!loaded) { BCPLOAD_DBG("load: could not resolve BCP exports\n"); return false; }
+#endif
+
+    // Require the core set:
+    out.loaded = true;
+    BCPLOAD_DBG("load: success\n");
+    return true;
+}
+
+/*=======================================================================================*/
+// Connection methods for BCP support
+/*=======================================================================================*/
+
+static const char* BCPCTX_CAPSULE = "pyodbc.BCPContext";
+
+// ---- tiny helpers ---------------------------------------
+static int is_space(char c) {
+    return c==' ' || c=='\t' || c=='\r' || c=='\n' || c=='\f';
+}
+static char up(char c) { return (c>='a' && c<='z') ? (char)(c - 'a' + 'A') : c; }
+
+// Skip whitespace and SQL-style comments
+static const char* skip_ws_and_comments(const char* p) {
+    for (;;) {
+        // whitespace
+        while (is_space(*p)) ++p;
+
+        // line comment: --
+        if (p[0]=='-' && p[1]=='-') {
+            p += 2;
+            while (*p && *p!='\n' && *p!='\r') ++p;
+            continue;
+        }
+        // block comment: /* ... */
+        if (p[0]=='/' && p[1]=='*') {
+            p += 2;
+            while (*p) {
+                if (p[0]=='*' && p[1]=='/') { p += 2; break; }
+                ++p;
+            }
+            continue;
+        }
+        return p;
+    }
+}
+
+// Case-insensitive match of a keyword; advances *pp on success
+static int match_kw(const char** pp, const char* kw) {
+    const char* p = *pp;
+    const char* k = kw;
+    while (*k) {
+        if (up(*p) != up(*k)) return 0;
+        ++p; ++k;
+    }
+    // ensure next char isn’t a letter/underscore continuing an identifier
+    char c = *p;
+    if ((c>='A' && c<='Z') || (c>='a' && c<='z') || c=='_') return 0;
+    *pp = p;
+    return 1;
+}
+
+// Parse bracketed identifier: starts at '[', supports ]] escape
+static int parse_bracket_ident(const char** pp, char* buf, int cap) {
+    const char* p = *pp; // p points to '['
+    ++p; // skip '['
+    int n = 0;
+    while (*p) {
+        if (*p == ']') {
+            if (p[1] == ']') { // escaped ] -> add one ]
+                if (n+1 >= cap) return -1;
+                buf[n++] = ']'; p += 2; continue;
+            } else {
+                ++p; // end
+                *pp = p;
+                if (n >= cap) return -1;
+                buf[n] = '\0';
+                return n;
+            }
+        }
+        if (n+1 >= cap) return -1;
+        buf[n++] = *p++;
+    }
+    return -1; // unterminated
+}
+
+// Parse quoted identifier: starts at '"', supports "" escape
+static int parse_quoted_ident(const char** pp, char* buf, int cap) {
+    const char* p = *pp; // points to '"'
+    ++p;
+    int n = 0;
+    while (*p) {
+        if (*p == '"') {
+            if (p[1] == '"') { // escaped "
+                if (n+1 >= cap) return -1;
+                buf[n++] = '"'; p += 2; continue;
+            } else {
+                ++p; // end
+                *pp = p;
+                if (n >= cap) return -1;
+                buf[n] = '\0';
+                return n;
+            }
+        }
+        if (n+1 >= cap) return -1;
+        buf[n++] = *p++;
+    }
+    return -1; // unterminated
+}
+
+// Parse bare identifier (letters, digits, _, $, #)
+static int is_ident_start(char c) {
+    return (c>='A'&&c<='Z') || (c>='a'&&c<='z') || c=='_' || c=='#' || c=='$';
+}
+
+// Check if the character is a valid part of the identifier 
+static int is_ident_part(char c) {
+    return is_ident_start(c) || (c>='0'&&c<='9');
+}
+
+// Parses a bare identifier from the input string into the buffer.
+static int parse_bare_ident(const char** pp, char* buf, int cap) {
+    const char* p = *pp;
+    if (!is_ident_start(*p)) return -1;
+    int n = 0;
+    while (is_ident_part(*p)) {
+        if (n+1 >= cap) return -1;
+        buf[n++] = *p++;
+    }
+    *pp = p;
+    if (n >= cap) return -1;
+    buf[n] = '\0';
+    return n;
+}
+
+// Parse a possibly quoted/bracketed identifier into buf
+static int parse_identifier(const char** pp, char* buf, int cap) {
+    const char* p = *pp;
+    if (*p == '[') {
+        int n = parse_bracket_ident(&p, buf, cap);
+        if (n < 0) return -1;
+        *pp = p; return n;
+    } else if (*p == '"') {
+        int n = parse_quoted_ident(&p, buf, cap);
+        if (n < 0) return -1;
+        *pp = p; return n;
+    } else {
+        int n = parse_bare_ident(&p, buf, cap);
+        if (n < 0) return -1;
+        *pp = p; return n;
+    }
+}
+
+// Skip a TOP ( ... ) [PERCENT] clause if present
+static void skip_top_clause(const char** pp) {
+    const char* p = *pp;
+    const char* save = p;
+    if (!match_kw(&p, "TOP")) return;   // not there
+    p = skip_ws_and_comments(p);
+    if (*p != '(') { *pp = save; return; }
+    // skip balanced parens depth 1
+    int depth = 0;
+    do {
+        if (*p == '(') ++depth;
+        else if (*p == ')') { --depth; if (depth==0) { ++p; break; } }
+        if (*p == '\0') { *pp = save; return; }
+        ++p;
+    } while (depth > 0);
+    p = skip_ws_and_comments(p);
+    // optional PERCENT
+    if (match_kw(&p, "PERCENT")) { /* ok */ }
+    *pp = p;
+}
+
+// Case-insensitive (ASCII-folded) UTF-16 string equality. Non-ASCII code units
+// must match exactly (we don't do Unicode case folding), which is correct when
+// the INSERT uses the same case as the table definition.
+static int ci_equal_w(const SQLWCHAR* a, const SQLWCHAR* b) {
+    while (*a && *b) {
+        SQLWCHAR ca = *a, cb = *b;
+        if (ca >= 'A' && ca <= 'Z') ca = (SQLWCHAR)(ca + 32);
+        if (cb >= 'A' && cb <= 'Z') cb = (SQLWCHAR)(cb + 32);
+        if (ca != cb) return 0;
+        ++a; ++b;
+    }
+    return *a == 0 && *b == 0;
+}
+
+// Convert a UTF-8 C string to a newly PyMem-allocated, NUL-terminated UTF-16LE
+// SQLWCHAR buffer (SQLWCHAR is 2 bytes on both Windows and unixODBC). Returns
+// NULL on failure (no Python exception left set).
+static SQLWCHAR* utf8_to_wide(const char* s) {
+    PyObject* u = PyUnicode_FromString(s);
+    if (!u) { PyErr_Clear(); return NULL; }
+    PyObject* b = PyUnicode_AsEncodedString(u, "utf-16-le", "strict");
+    Py_DECREF(u);
+    if (!b) { PyErr_Clear(); return NULL; }
+    Py_ssize_t nbytes = PyBytes_GET_SIZE(b);
+    SQLWCHAR* w = (SQLWCHAR*)PyMem_Malloc((size_t)nbytes + sizeof(SQLWCHAR));
+    if (!w) { Py_DECREF(b); return NULL; }
+    memcpy(w, PyBytes_AS_STRING(b), (size_t)nbytes);
+    w[nbytes / (Py_ssize_t)sizeof(SQLWCHAR)] = 0;
+    Py_DECREF(b);
+    return w;
+}
+
+// Append a copy of s[0..len) to a growable PyMem array. Returns 1 on success.
+static int names_append(char*** names, int* count, int* cap, const char* s, int len) {
+    if (*count == *cap) {
+        int ncap = *cap ? *cap * 2 : 8;
+        char** np = (char**)PyMem_Realloc(*names, (size_t)ncap * sizeof(char*));
+        if (!np) return 0;
+        *names = np; *cap = ncap;
+    }
+    char* copy = (char*)PyMem_Malloc((size_t)len + 1);
+    if (!copy) return 0;
+    memcpy(copy, s, (size_t)len);
+    copy[len] = '\0';
+    (*names)[(*count)++] = copy;
+    return 1;
+}
+
+void bcp_free_names(char** names, int n) {
+    if (!names) return;
+    for (int i = 0; i < n; ++i) PyMem_Free(names[i]);
+    PyMem_Free(names);
+}
+
+int parse_insert_target(const char* sql,
+                        char* tableref, int tableref_cap,
+                        char* schema, int schema_cap,
+                        char* table, int table_cap,
+                        char*** out_names, int* out_ncols)
+{
+    *out_names = NULL;
+    *out_ncols = 0;
+    if (schema_cap > 0) schema[0] = '\0';
+
+    const char* p = sql;
+    p = skip_ws_and_comments(p);
+    if (!match_kw(&p, "INSERT")) return 0;
+
+    // optional stuff between INSERT and INTO (e.g. TOP (...) PERCENT)
+    p = skip_ws_and_comments(p);
+    skip_top_clause(&p);
+    p = skip_ws_and_comments(p);
+
+    if (!match_kw(&p, "INTO")) return 0;
+    p = skip_ws_and_comments(p);
+
+    // Parse up to a 3-part name ([cat.][schema.]table), recording the verbatim
+    // reference (for bcp_init) and the unquoted parts (for SQLColumns).
+    char parts[3][256];
+    int nparts = 0;
+    const char* refStart = p;
+    const char* refEnd = p;
+    for (;;) {
+        if (nparts >= 3) return 0;
+        if (parse_identifier(&p, parts[nparts], (int)sizeof(parts[0])) < 0) return 0;
+        ++nparts;
+        refEnd = p;
+        const char* save = p;
+        p = skip_ws_and_comments(p);
+        if (*p == '.') { ++p; p = skip_ws_and_comments(p); continue; }
+        p = save;
+        break;
+    }
+
+    const char* tbl = parts[nparts - 1];
+    const char* sch = (nparts >= 2) ? parts[nparts - 2] : "";
+
+    int tn = 0; while (tbl[tn]) ++tn;
+    if (tn <= 0 || tn >= table_cap) return 0;
+    memcpy(table, tbl, (size_t)tn + 1);
+
+    int sn = 0; while (sch[sn]) ++sn;
+    if (sn >= schema_cap) return 0;
+    memcpy(schema, sch, (size_t)sn + 1);
+
+    int rn = (int)(refEnd - refStart);
+    if (rn <= 0 || rn >= tableref_cap) return 0;
+    memcpy(tableref, refStart, (size_t)rn);
+    tableref[rn] = '\0';
+
+    p = skip_ws_and_comments(p);
+
+    // Optional explicit column list. BCP binds by ordinal, so the caller maps
+    // these names to table ordinals (see bcp_resolve_ordinals).
+    char** names = NULL;
+    int count = 0, cap = 0;
+    if (*p == '(') {
+        ++p;
+        for (;;) {
+            p = skip_ws_and_comments(p);
+            char ident[256];
+            if (parse_identifier(&p, ident, (int)sizeof(ident)) < 0) { bcp_free_names(names, count); return 0; }
+            int il = 0; while (ident[il]) ++il;
+            if (!names_append(&names, &count, &cap, ident, il)) {
+                bcp_free_names(names, count); PyErr_NoMemory(); return 0;
+            }
+            p = skip_ws_and_comments(p);
+            if (*p == ',') { ++p; continue; }
+            if (*p == ')') { ++p; break; }
+            bcp_free_names(names, count); return 0;   // malformed list
+        }
+        p = skip_ws_and_comments(p);
+    }
+
+    // Require VALUES: reject INSERT ... SELECT/EXEC, DEFAULT VALUES, table hints.
+    if (!match_kw(&p, "VALUES")) { bcp_free_names(names, count); return 0; }
+
+    *out_names = names;
+    *out_ncols = count;
+    return 1;
+}
+
+int bcp_resolve_ordinals(HDBC hdbc, const char* schema, const char* table,
+                         char** names, int n, int* out_ord, int* out_total)
+{
+    for (int i = 0; i < n; ++i) out_ord[i] = 0;
+    *out_total = 0;
+
+    // All names go through SQLColumnsW (Unicode) so non-ASCII column names work;
+    // everything is compared as UTF-16.
+    int result = 0;
+    SQLRETURN rc;
+    HSTMT hstmt = SQL_NULL_HANDLE;
+    SQLWCHAR* table_w = NULL;
+    SQLWCHAR* schema_w = NULL;            // heap copy of an explicit schema
+    SQLWCHAR  schema_default[256];        // from SCHEMA_NAME()
+    SQLWCHAR* schema_arg = NULL;          // -> schema_w or schema_default
+    SQLWCHAR** name_w = NULL;
+    int names_built = 0;
+
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, hdbc, &hstmt))) { hstmt = SQL_NULL_HANDLE; goto done; }
+
+    name_w = (SQLWCHAR**)PyMem_Calloc((size_t)n, sizeof(SQLWCHAR*));
+    if (!name_w) goto done;
+    for (int i = 0; i < n; ++i) {
+        name_w[i] = utf8_to_wide(names[i]);
+        if (!name_w[i]) goto done;
+        names_built = i + 1;
+    }
+
+    table_w = utf8_to_wide(table);
+    if (!table_w) goto done;
+
+    if (schema && schema[0]) {
+        schema_w = utf8_to_wide(schema);
+        if (!schema_w) goto done;
+        schema_arg = schema_w;
+    } else {
+        // The INSERT omitted the schema: resolve the connection's default schema
+        // and pass it explicitly. SQLColumns with a NULL schema returns columns
+        // for EVERY table of this name in EVERY schema, which would inflate the
+        // column count and could resolve an ordinal from the wrong table --
+        // whereas bcp_init resolves the unqualified name against the default
+        // schema. Pinning both to the same schema keeps the ordinals consistent.
+        schema_default[0] = 0;
+        Py_BEGIN_ALLOW_THREADS
+        rc = SQLExecDirectW(hstmt, (SQLWCHAR*)u"SELECT SCHEMA_NAME()", SQL_NTS);
+        Py_END_ALLOW_THREADS
+        if (SQL_SUCCEEDED(rc)) {
+            SQLLEN cb = 0;
+            SQLBindCol(hstmt, 1, SQL_C_WCHAR, schema_default, (SQLLEN)sizeof(schema_default), &cb);
+            Py_BEGIN_ALLOW_THREADS
+            rc = SQLFetch(hstmt);
+            Py_END_ALLOW_THREADS
+            if ((rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) || cb == SQL_NULL_DATA)
+                schema_default[0] = 0;
+        }
+        SQLFreeStmt(hstmt, SQL_CLOSE);
+        SQLFreeStmt(hstmt, SQL_UNBIND);
+        if (!schema_default[0]) goto done;   // couldn't resolve -> fall back
+        schema_arg = schema_default;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = SQLColumnsW(hstmt, NULL, 0, schema_arg, SQL_NTS, table_w, SQL_NTS, NULL, 0);
+    Py_END_ALLOW_THREADS
+    if (!SQL_SUCCEEDED(rc)) goto done;
+
+    {
+        // SQLColumns result columns: 4 = COLUMN_NAME, 17 = ORDINAL_POSITION.
+        SQLWCHAR wcolname[256];
+        SQLINTEGER ordinal = 0;
+        SQLLEN cbName = 0, cbOrd = 0;
+        SQLBindCol(hstmt, 4, SQL_C_WCHAR, wcolname, (SQLLEN)sizeof(wcolname), &cbName);
+        SQLBindCol(hstmt, 17, SQL_C_SLONG, &ordinal, 0, &cbOrd);
+        for (;;) {
+            Py_BEGIN_ALLOW_THREADS
+            rc = SQLFetch(hstmt);
+            Py_END_ALLOW_THREADS
+            if (rc == SQL_NO_DATA) break;
+            if (!SQL_SUCCEEDED(rc)) goto done;
+            if (cbName == SQL_NULL_DATA || cbOrd == SQL_NULL_DATA) continue;
+            ++(*out_total);
+            for (int i = 0; i < n; ++i)
+                if (out_ord[i] == 0 && ci_equal_w(name_w[i], wcolname))
+                    out_ord[i] = (int)ordinal;
+        }
+    }
+
+    result = 1;
+    for (int i = 0; i < n; ++i)
+        if (out_ord[i] <= 0) result = 0;   // a listed column was not found
+    // Reject duplicate/aliased names that resolved to the same ordinal: that
+    // would bind two host columns to one server column and leave another unbound.
+    for (int i = 0; i < n && result; ++i)
+        for (int j = i + 1; j < n; ++j)
+            if (out_ord[i] == out_ord[j]) { result = 0; break; }
+
+done:
+    if (hstmt != SQL_NULL_HANDLE) SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+    if (name_w) { for (int i = 0; i < names_built; ++i) PyMem_Free(name_w[i]); PyMem_Free(name_w); }
+    PyMem_Free(table_w);
+    PyMem_Free(schema_w);
+    return result;
+}
+
+// Dynamicaly loads BCP specific dependencies 
+bool ensure_bcp_loaded(Connection* self) {
+    if (self->bcp && self->bcp->loaded) return true;
+    if (!self->hdbc) return false;
+    if (!self->bcp) {
+        self->bcp = (BcpProcs*)PyMem_Calloc(1, sizeof(BcpProcs));
+        if (!self->bcp) { PyErr_NoMemory(); return false; }
+    }
+    return BcpLoadFromDriver(self->hdbc, *self->bcp);
+}
+
+// Frees the BCP context capsule 
+void BcpCtx_FreeCapsule(PyObject* cap) 
+{
+    BcpCtx* ctx = (BcpCtx*)PyCapsule_GetPointer(cap, BCPCTX_CAPSULE);
+    if (!ctx) return;
+    if (ctx->cols) {
+        for (int i = 0; i < ctx->ncols; ++i) {
+            if (ctx->cols[i].scratch) PyMem_Free(ctx->cols[i].scratch);
+        }
+        PyMem_Free(ctx->cols);
+    }
+    PyMem_Free(ctx);
+}
+
+// Update the driver’s pointer to this column’s data buffer
+int _bcp_set_colptr(BcpCtx* ctx, BcpCol* c)
+{
+    SQLRETURN rc;
+    Py_BEGIN_ALLOW_THREADS
+    rc = ctx->conn->bcp->bcp_colptr(ctx->conn->hdbc, (LPCBYTE)c->scratch, c->ordinal);
+    Py_END_ALLOW_THREADS
+    return (rc != FAIL);
+}
+
+// Free context buffer and clear pointer 
+void _bcp_ctx_free(BcpCtx* ctx) {
+    if (!ctx) return;
+    if (ctx->cols) {
+        for (int i = 0; i < ctx->ncols; ++i)
+            if (ctx->cols[i].scratch) PyMem_Free(ctx->cols[i].scratch);
+        PyMem_Free(ctx->cols);
+    }
+    PyMem_Free(ctx);
+}
+
+// Binds the buffer for the pased column 
+int _bcp_rebind_current(BcpCtx* ctx, BcpCol* c)
+{
+    // When we grow a varlen buffer, tell the driver the new max length.
+    const DBINT cbIndicator = 0;
+    const DBINT cbData  = c->isVarLen ? SQL_VARLEN_DATA : (DBINT)c->fixedSize;
+
+    SQLRETURN rc;
+    Py_BEGIN_ALLOW_THREADS
+    rc = ctx->conn->bcp->bcp_bind(ctx->conn->hdbc, (LPCBYTE)c->scratch, cbIndicator, cbData, NULL, 0, c->hostType, c->ordinal);
+    Py_END_ALLOW_THREADS
+
+    return (rc == SUCCEED);
+}
+
+// Binds buffers for all defined column types 
+int _bcp_bind_all(BcpCtx* ctx)
+{
+    for (int i = 0; i < ctx->ncols; ++i)
+    {
+        BcpCol* c = &ctx->cols[i];
+
+        // Ensure scratch exists and has at least 1 byte.
+        if (!c->scratch || c->scratchCap == 0) 
+        {
+            PyErr_SetString(PyExc_RuntimeError, "Internal error: BCP column scratch buffer not allocated.");
+            return 0;
+        }
+
+        // We bind a single, persistent host buffer per column.
+        // For fixed types it's the exact size; for varlen we set isVarlen = 0 and set length per row via bcp_collen.
+        const DBINT cbIndicator = 0;  // we keep the cbIndicator 0, this works for both static and var lengths 
+        const DBINT cbData = c->isVarLen ? SQL_VARLEN_DATA : (DBINT)c->fixedSize;
+
+        RETCODE rc = ctx->conn->bcp->bcp_bind(ctx->conn->hdbc,
+                              (LPCBYTE)c->scratch,  // driver reads from here on each sendrow
+                              cbIndicator,
+                              cbData,               // 0 for varlen; sizeof(T) for fixed
+                              /*pTerm*/ NULL,
+                              /*cbTerm*/ 0,
+                              /*eDataType*/ c->hostType,
+                              /*server col*/ c->ordinal);
+        if (rc != SUCCEED)
+            return 0;
+    }
+    return 1;
+
+}
+
+// Convert one Python cell into a column scratch buffer + set length via bcp_collen.
+// NULL -> SQL_NULL_DATA via bcp_collen for both fixed & varlen.
+int _bcp_fill_cell(BcpCtx* ctx, PyObject* cell, BcpCol* c)
+{
+    // NULL for this column on this row
+    if (cell == Py_None)
+    {
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, SQL_NULL_DATA, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+
+    switch (c->hostType)
+    {
+    case SQLBIT: {
+        int truthy = PyObject_IsTrue(cell);
+        if (truthy < 0) return 0;       // error converting
+        unsigned char b = truthy ? 1 : 0;
+        memcpy(c->scratch, &b, 1);
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, 1, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLINT2: {
+        long v = PyLong_AsLong(cell);
+        if (PyErr_Occurred()) return 0;
+        if (v < SHRT_MIN || v > SHRT_MAX) {
+            PyErr_SetString(PyExc_OverflowError, "SMALLINT out of range");
+            return 0;
+        }
+        short s = (short)v;
+        memcpy(c->scratch, &s, sizeof(short));
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(short), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLINT4:
+    {
+        long long lv = PyLong_AsLongLong(cell);
+        if (PyErr_Occurred()) return 0;
+        if (lv < -2147483648LL || lv > 2147483647LL) {
+            PyErr_SetString(PyExc_OverflowError, "INTEGER value out of range for BCP column");
+            return 0;
+        }
+        DBINT v = (DBINT)lv;
+        memcpy(c->scratch, &v, sizeof(DBINT));
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(DBINT), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLINT8: {
+        long long v = PyLong_AsLongLong(cell);
+        if (PyErr_Occurred()) return 0;
+        memcpy(c->scratch, &v, sizeof(long long));
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(long long), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLFLT8:
+    {
+        // PyFloat_AsDouble also accepts ints (no need for PyFloat_Check here)
+        double d = PyFloat_AsDouble(cell);
+        if (PyErr_Occurred()) return 0;
+        memcpy(c->scratch, &d, sizeof(double));
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(double), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLFLT4: {
+        double dv = PyFloat_AsDouble(cell);
+        if (PyErr_Occurred()) return 0;
+        float fv = (float)dv;
+        memcpy(c->scratch, &fv, sizeof(float));
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(float), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLBINARY: {
+        const char* p = NULL;
+        Py_ssize_t n = 0;
+        PyObject* bytes_obj = NULL;
+
+        if (PyBytes_Check(cell)) {
+            bytes_obj = cell; Py_INCREF(bytes_obj);
+            p = PyBytes_AS_STRING(bytes_obj);
+            n = PyBytes_GET_SIZE(bytes_obj);
+        } else if (PyByteArray_Check(cell)) {
+            p = PyByteArray_AsString(cell);
+            n = PyByteArray_Size(cell);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "Expected bytes/bytearray for VARBINARY/BINARY");
+            return 0;
+        }
+
+        DBINT bytes = (DBINT)n;
+        if (bytes > c->scratchCap) {
+            unsigned char* np = (unsigned char*)PyMem_Realloc(c->scratch, (size_t)bytes);
+            if (!np) { Py_XDECREF(bytes_obj); PyErr_NoMemory(); return 0; }
+            c->scratch = np; c->scratchCap = bytes;
+            if (!_bcp_rebind_current(ctx, c)) { Py_XDECREF(bytes_obj); return 0; }
+        }
+        if (bytes > 0) memcpy(c->scratch, p, (size_t)bytes);
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, bytes, c->ordinal);
+        Py_END_ALLOW_THREADS
+
+        Py_XDECREF(bytes_obj);
+        return (rc != FAIL);
+    }
+    case SQLUNIQUEID: {
+        unsigned char buf[16];
+        int ok = 0;
+        if (PyObject_HasAttrString(cell, "bytes_le")) {
+            PyObject* le = PyObject_GetAttrString(cell, "bytes_le");
+            if (le) {
+                if (PyBytes_Check(le) && PyBytes_GET_SIZE(le) == 16) {
+                    memcpy(buf, PyBytes_AS_STRING(le), 16);
+                    ok = 1;
+                }
+                Py_DECREF(le);
+            }
+        } else if (PyBytes_Check(cell) && PyBytes_GET_SIZE(cell) == 16) {
+            memcpy(buf, PyBytes_AS_STRING(cell), 16);
+            ok = 1;
+        }
+        if (!ok) {
+            PyErr_SetString(PyExc_TypeError, "GUID requires uuid.UUID or 16-byte bytes");
+            return 0;
+        }
+        memcpy(c->scratch, buf, 16);
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, 16, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLCHARACTER:
+    {
+        const char* p = NULL;
+        Py_ssize_t n = 0;
+
+        if (PyUnicode_Check(cell)) {
+            p = PyUnicode_AsUTF8AndSize(cell, &n);   // <-- NO allocation
+            if (!p) return 0;
+        } else if (PyBytes_Check(cell)) {
+            p = PyBytes_AsString(cell);
+            if (!p) return 0;
+            n = PyBytes_GET_SIZE(cell);
+        } else if (PyByteArray_Check(cell)) {
+            p = PyByteArray_AsString(cell);
+            n = PyByteArray_Size(cell);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "Expected str/bytes/bytearray for SQLCHARACTER");
+            return 0;
+        }
+
+        DBINT bytes = (DBINT)n;
+
+        if (bytes > c->scratchCap) {
+            unsigned char* np = (unsigned char*)PyMem_Realloc(c->scratch, (size_t)bytes);
+            if (!np) { PyErr_NoMemory(); return 0; }
+            c->scratch = np;
+            c->scratchCap = bytes;
+            if (!_bcp_rebind_current(ctx, c)) return 0;
+        }
+
+        if (bytes > 0)
+            memcpy(c->scratch, p, (size_t)bytes);
+
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, bytes, c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    case SQLTIMEN: {
+        PyObject* hh = PyObject_GetAttrString(cell, "hour");
+        PyObject* mm = PyObject_GetAttrString(cell, "minute");
+        PyObject* ss = PyObject_GetAttrString(cell, "second");
+        PyObject* us = PyObject_GetAttrString(cell, "microsecond");
+        if (!hh || !mm || !ss || !us) { Py_XDECREF(hh); Py_XDECREF(mm); Py_XDECREF(ss); Py_XDECREF(us);
+            PyErr_SetString(PyExc_TypeError, "TIME expects time/datetime"); return 0; }
+        TIME_STRUCT ts;
+        ts.hour   = (SQLUSMALLINT)PyLong_AsUnsignedLong(hh);
+        ts.minute = (SQLUSMALLINT)PyLong_AsUnsignedLong(mm);
+        ts.second = (SQLUSMALLINT)PyLong_AsUnsignedLong(ss);
+        Py_DECREF(hh); Py_DECREF(mm); Py_DECREF(ss);
+        if (PyErr_Occurred()) { Py_XDECREF(us); return 0; }
+
+        // Store fractional seconds in TIMESTAMP_STRUCT only; TIME_STRUCT has no fraction field.
+        // For TIME(p) precision, the driver will handle scale; to keep sub-second precision,
+        // prefer TIMESTAMP_STRUCT + SQLTIMESTAMP (or send text). For pure TIME, send "HH:MM:SS[.fff]" as text (Option A),
+        // or accept second-only here:
+        Py_XDECREF(us);
+
+        memcpy(c->scratch, &ts, sizeof(ts));
+        SQLRETURN rc; Py_BEGIN_ALLOW_THREADS
+        rc = ctx->conn->bcp->bcp_collen(ctx->conn->hdbc, (DBINT)sizeof(TIME_STRUCT), c->ordinal);
+        Py_END_ALLOW_THREADS
+        return (rc != FAIL);
+    }
+    default:
+        PyErr_SetString(PyExc_TypeError, "Unsupported host type in types[]");
+        return 0;
+    }
+}
+
+// helpers (top of file)
+void write_le(unsigned char* dst, unsigned long long v, int len) {
+    for (int i = 0; i < len; ++i) dst[i] = (unsigned char)((v >> (8*i)) & 0xFF);
+}
+
+// time ticks for TIME(7): 10^-7s since midnight
+unsigned long long time_to_ticks7(int hh, int mm, int ss, int micro) {
+    unsigned long long sec = (unsigned long long)hh*3600ULL + (unsigned long long)mm*60ULL + (unsigned long long)ss;
+    return sec * 10000000ULL + (unsigned long long)micro * 10ULL; // 1 micro = 10 * 1e-7
+}
+
+// days since 0001-01-01; 0001-01-01 = 0
+unsigned int days_since_0001_01_01(int y, int m, int d)
+{
+    // Howard Hinnant’s days-from-civil (adapted), shifted so 0001-01-01 = 0
+    y -= m <= 2;
+    const int era = (y >= 0 ? y : y-399) / 400;
+    const unsigned yoe = (unsigned)(y - era * 400);           // [0, 399]
+    const unsigned doy = (153*(m + (m > 2 ? -3 : 9)) + 2)/5 + d - 1; // [0, 365]
+    const unsigned doe = yoe*365 + yoe/4 - yoe/100 + doy;     // [0, 146096]
+    // days since 0000-03-01; convert to 0001-01-01 base:
+    // 0001-01-01 is 306 days after 0000-03-01.
+    const int days = era*146097 + (int)doe - 306;
+    return (unsigned int)days; // 0 for 0001-01-01
+}

--- a/src/bcp_support.h
+++ b/src/bcp_support.h
@@ -1,0 +1,340 @@
+#pragma once
+
+// --- Windows prerequisites so ODBC SAL/GUID types are present everywhere this header is used
+#ifdef _WIN32
+    #ifndef NOMINMAX
+    #define NOMINMAX
+    #endif
+    #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+    #endif
+    #include <windows.h>
+#else
+    #include <dlfcn.h>
+#endif
+
+#ifndef ODBCVER
+    #define ODBCVER 0x0380
+#endif
+
+// --- ODBC prerequisites
+#include <sql.h>
+#include <sqlext.h>
+
+// --- Provide minimal typedefs if the BCP headers are not included
+
+/* ---- DB-Library style constants used by the BCP API ---- */
+#ifndef DB_IN
+#define DB_IN 1
+#endif
+#ifndef DB_OUT
+#define DB_OUT 2
+#endif
+#ifndef SUCCEED
+#define SUCCEED 1
+#endif
+#ifndef FAIL
+#define FAIL 0
+#endif
+
+#ifndef DBINT
+// DBINT is 32-bit signed in the SQL Server driver. Must be `int`, not `long`:
+// on LP64 (Linux/macOS) `long` is 8 bytes, which makes sizeof(DBINT) wrong for
+// SQLINT4 binds and mismatches the driver's bcp_bind ABI.
+typedef int DBINT;
+#endif
+
+#ifndef BYTE
+typedef unsigned char BYTE;
+#endif
+#ifndef LPCBYTE
+typedef const BYTE* LPCBYTE;
+#endif
+
+// ---- Minimal constants (used only if you can't include msodbcsql.h)
+#ifndef SQL_COPT_SS_BCP
+#define SQL_COPT_SS_BCP 1219       // ODBC Driver 17/18
+#endif
+#ifndef SQL_BCP_ON
+#define SQL_BCP_ON 1
+#endif
+#ifndef SQL_VARLEN_DATA
+#define SQL_VARLEN_DATA (-10)
+#endif
+
+// Supported Host types (fallbacks; prefer exporting real ones from the module)
+#ifndef SQLBIT                  // BIT (1 byte)
+#define SQLBIT  0x32
+#endif
+#ifndef SQLINT2                 // SMALLINT (2 bytes)
+#define SQLINT2 0x34
+#endif
+#ifndef SQLINT4                 // INTEGER (4 bytes)
+#define SQLINT4 0x38               
+#endif
+#ifndef SQLINT8                 // BIGINT (8 bytes)
+#define SQLINT8 0x7F
+#endif
+#ifndef SQLFLT8                 // FLOAT (8 bytes)
+#define SQLFLT8 0x3E               
+#endif
+#ifndef SQLFLT4                 // REAL / FLOAT(24) (4 bytes)
+#define SQLFLT4 0x3B
+#endif
+#ifndef SQLBINARY               // BINARY / VARBINARY host type
+#define SQLBINARY 0x2D
+#endif
+#ifndef SQLUNIQUEID             // UNIQUEIDENTIFIER host type
+#define SQLUNIQUEID 0x24
+#endif
+#ifndef SQLCHARACTER            // CHAR / VARCHAR / TEXT host type
+#define SQLCHARACTER 0x2F          
+#endif
+#ifndef SQLTIMEN                // host type for TIME_STRUCT
+#define SQLTIMEN 0x29
+#endif
+#ifndef SQLDATEN
+#define SQLDATEN 0x28
+#endif
+#ifndef SQLDATETIME2N
+#define SQLDATETIME2N 0x2A
+#endif
+#ifndef SQLDATETIMEOFFSETN
+#define SQLDATETIMEOFFSETN 0x2B
+#endif
+
+// Supported bcp_control options (guarded):
+#ifndef BCPBATCH
+#define BCPBATCH 4              // same as msodbcsql.h
+#endif
+#ifndef BCPMAXERRS
+#define BCPMAXERRS 1            // same as msodbcsql.h
+#endif
+#ifndef BCPKEEPNULLS
+#define BCPKEEPNULLS 5          // same as msodbcsql.h
+#endif
+#ifndef BCPHINTS
+#define BCPHINTS 10             // same as msodbcsql.h
+#endif
+
+struct Connection;  // forward declaration
+
+struct BcpProcs {
+    // ANSI signatures (the A-suffixed variants)
+    SQLRETURN (SQL_API *bcp_initA)(HDBC, const char*, const char*, const char*, int);
+    SQLRETURN (SQL_API *bcp_bind)  (HDBC, const BYTE*, int, DBINT, const BYTE*, int, int, int);
+    SQLRETURN (SQL_API *bcp_collen)(HDBC, DBINT, int);
+    SQLRETURN (SQL_API *bcp_colptr)(HDBC, const BYTE*, int);
+    SQLRETURN (SQL_API *bcp_sendrow)(HDBC);
+    DBINT     (SQL_API *bcp_batch)(HDBC);
+    DBINT     (SQL_API *bcp_done)(HDBC);
+    SQLRETURN (SQL_API *bcp_control)(HDBC, int, void*);
+    bool loaded = false;
+};
+
+// Load once per connection
+bool BcpLoadFromDriver(HDBC hdbc, BcpProcs& out);
+
+// Convenience macro to check availability
+#define HAS_BCP(p) ((p).loaded)
+
+static inline char lower_ascii(char c) { return (c >= 'A' && c <= 'Z') ? char(c + 32) : c; }
+
+typedef struct BcpCol_
+{
+    int ordinal;                // 1-based
+    int hostType;               // SQLINT4, SQLFLT8, SQLCHARACTER, SQLINT2, SQLINT8...
+    bool isVarLen;              // 1 if varlen (SQLCHARACTER), else 0
+    int ind;                    // byte length indicator for varlen; always 0 for fixed
+    size_t fixedSize;           // for fixed types
+    unsigned char* scratch;     // reusable per-column buffer
+    DBINT scratchCap;           // bytes
+    bool was_null;              // true if the previous row bound SQL_NULL_DATA for this column
+} BcpCol;
+
+typedef struct BcpCtx_ {
+    Connection* conn;                   // borrowed from Connection
+    int         ncols;
+    BcpCol*     cols;
+    DBINT       total_committed;        // running total (optional)
+} BcpCtx;
+
+/**
+ * @brief Parses "INSERT INTO [[cat.]schema.]table [ (col, ...) ] VALUES" for BCP.
+ *
+ * Extracts the verbatim qualified table reference (for bcp_init), the unquoted
+ * schema and table names (for SQLColumns), and the optional explicit column
+ * list. Only a parameterized VALUES insert is accepted; INSERT ... SELECT/EXEC,
+ * table hints and DEFAULT VALUES return 0 so the caller falls back.
+ *
+ * @param sql          The SQL INSERT statement (null-terminated).
+ * @param tableref     Output buffer for the verbatim table reference.
+ * @param tableref_cap Capacity of tableref.
+ * @param schema       Output buffer for the unquoted schema ("" if none).
+ * @param schema_cap   Capacity of schema.
+ * @param table        Output buffer for the unquoted table name.
+ * @param table_cap    Capacity of table.
+ * @param out_names    Receives a PyMem-allocated array of column-name strings
+ *                     (NULL if no explicit list); free with bcp_free_names().
+ * @param out_ncols    Receives the number of column names (0 if no list).
+ * @return 1 on success, 0 to fall back (PyErr may be set on allocation failure).
+ */
+int parse_insert_target(const char* sql,
+                        char* tableref, int tableref_cap,
+                        char* schema, int schema_cap,
+                        char* table, int table_cap,
+                        char*** out_names, int* out_ncols);
+
+/** @brief Frees the column-name array produced by parse_insert_target(). */
+void bcp_free_names(char** names, int n);
+
+/**
+ * @brief Resolves column names to 1-based table ordinals via SQLColumns.
+ *
+ * Used to honour an explicit INSERT column list: BCP binds by ordinal, so each
+ * named column must be mapped to its position in the destination table.
+ *
+ * @param hdbc     Connection handle (a temporary statement is allocated on it).
+ * @param schema   Unquoted schema, or "" / NULL to match the default schema.
+ * @param table    Unquoted table name.
+ * @param names      Column names to resolve.
+ * @param n          Number of names.
+ * @param out_ord    Receives the 1-based ordinal for each name.
+ * @param out_total  Receives the total number of columns in the table (so the
+ *                   caller can detect a partial column list, which BCP cannot
+ *                   honour without overriding column DEFAULTs).
+ * @return 1 if every name resolved, 0 otherwise.
+ */
+int bcp_resolve_ordinals(HDBC hdbc, const char* schema, const char* table,
+                         char** names, int n, int* out_ord, int* out_total);
+
+/**
+ * @brief Ensures that the Bulk Copy Program (BCP) library is loaded for the given connection.
+ *
+ * This function checks if the BCP library required for bulk data operations is loaded
+ * for the specified connection. If not, it attempts to load the library.
+ *
+ * @param self Pointer to the Connection object for which the BCP library should be loaded.
+ * @return true if the BCP library is successfully loaded or already loaded; false otherwise.
+ */
+bool ensure_bcp_loaded(Connection* self);
+
+/**
+ * @brief Frees resources associated with a BCP context capsule.
+ *
+ * This function is intended to be used as a destructor for Python capsule objects
+ * that encapsulate BCP (Bulk Copy Program) context data. It releases any memory or
+ * resources held by the capsule to prevent memory leaks.
+ *
+ * @param cap A pointer to the Python capsule object containing the BCP context.
+ */
+void BcpCtx_FreeCapsule(PyObject* cap);
+
+/**
+ * @brief Sets the column pointer for a BCP column in the given context.
+ *
+ * This function assigns the appropriate data pointer for the specified column
+ * within the Bulk Copy Program (BCP) context. It is typically used to prepare
+ * the column for data transfer operations.
+ *
+ * @param ctx Pointer to the BCP context structure.
+ * @param c Pointer to the BCP column structure whose data pointer is to be set.
+ * @return Returns 0 on success, or a non-zero error code on failure.
+ */
+int _bcp_set_colptr(BcpCtx* ctx, BcpCol* c);
+
+/**
+ * @brief Frees the resources associated with a BcpCtx context.
+ *
+ * This function releases all memory and resources allocated for the specified
+ * BcpCtx structure. After calling this function, the context pointer should not
+ * be used unless reinitialized.
+ *
+ * @param ctx Pointer to the BcpCtx context to be freed.
+ */
+void _bcp_ctx_free(BcpCtx* ctx);
+
+/**
+ * @brief Rebinds the current column in the BCP context.
+ *
+ * This function updates the binding of the specified column within the given BCP context.
+ * It is typically used when the column's data type or binding parameters have changed and
+ * need to be reapplied for bulk copy operations. Most common cause buffer size increase.
+ *
+ * @param ctx Pointer to the BCP context structure.
+ * @param c Pointer to the BCP column structure to be rebound.
+ * @return Returns 0 on success, or a non-zero error code on failure.
+ */
+int _bcp_rebind_current(BcpCtx* ctx, BcpCol* c);
+
+/**
+ * @brief Bind all column buffers for bulk copy (BCP) operations.
+ *
+ * Iterates over all columns in the given BCP context and binds each column’s
+ * scratch buffer using `bcp_bind()`. For fixed-size columns, the exact size is bound;
+ * for variable-length columns, the size is set per row via `bcp_collen()`.
+ *
+ * Fails if a column has no scratch buffer or if any bind call fails.
+ *
+ * @param ctx  Pointer to an initialized BCP context with valid column metadata.
+ * @return 1 on success, 0 on error (Python exception set).
+ */
+int _bcp_bind_all(BcpCtx* ctx);
+
+/**
+ * @brief Converts a Python value to a native buffer and binds it for BCP.
+ *
+ * Converts a single Python object to the column’s native type and writes it
+ * into the column’s scratch buffer. Then updates the column length using
+ * `bcp_collen()`. Handles `None` as SQL NULL and supports various SQL types
+ * (BIT, INT2/4/8, FLOAT4/8, BINARY, CHAR, UNIQUEID, TIMEN, etc.).
+ *
+ * @param ctx   Active BCP context.
+ * @param cell  Python object representing the cell value.
+ * @param c     Target column descriptor.
+ * @return 1 on success, 0 on error (Python exception set).
+ */
+int _bcp_fill_cell(BcpCtx* ctx, PyObject* cell, BcpCol* c);
+
+/**
+ * @brief Write an integer value to a buffer in little-endian order.
+ *
+ * Stores the lower @p len bytes of @p v into @p dst, least significant byte first.
+ *
+ * @param dst  Destination buffer.
+ * @param v    Integer value to write.
+ * @param len  Number of bytes to write (1–8).
+ */
+void write_le(unsigned char* dst, unsigned long long v, int len);
+
+/**
+ * @brief Convert a time value to SQL Server TIME(7) ticks.
+ *
+ * Computes the number of 100-nanosecond ticks since midnight,
+ * where 1 microsecond equals 10 ticks.
+ *
+ * @param hh     Hours (0–23).
+ * @param mm     Minutes (0–59).
+ * @param ss     Seconds (0–59).
+ * @param micro  Microseconds (0–999999).
+ * @return Time in 10⁻⁷-second ticks since midnight.
+ */
+unsigned long long time_to_ticks7(int hh, int mm, int ss, int micro);
+
+/**
+ * @brief Compute days since 0001-01-01 (proleptic Gregorian).
+ *
+ * Converts a civil date (y, m, d) to a day count where 0001-01-01 == 0.
+ * Implementation is based on Howard Hinnant’s days-from-civil algorithm.
+ *
+ * @param y Year (e.g., 2025). Proleptic Gregorian; no BCE/0-year handling.
+ * @param m Month in [1, 12].
+ * @param d Day in [1, 31] (no range validation performed).
+ * @return unsigned int Days since 0001-01-01 (0 for 0001-01-01).
+ *
+ * @note Inputs are assumed valid; behavior is undefined for invalid dates.
+ */
+unsigned int days_since_0001_01_01(int y, int m, int d);
+
+// --- Constant for conversion from days since 0001-01-01 to days since 1900-01-01
+static const unsigned int DAYS_0001_TO_1900 = 693595U;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -16,7 +16,7 @@
 #include "pyodbcmodule.h"
 #include "errors.h"
 #include "cnxninfo.h"
-
+#include "bcp_support.h"
 
 static char connection_doc[] =
     "Connection objects manage connections to the database.\n"
@@ -308,6 +308,7 @@ PyObject* Connection_New(PyObject* pConnectString, bool fAutoCommit, long timeou
     cnxn->map_sqltype_to_converter = 0;
     cnxn->readvar_initsize = 4096;
     cnxn->compat_diagrec_byte_length = false;
+    cnxn->bcp          = NULL;
 
     cnxn->attrs_before = attrs_before_o.Detach();
     cnxn->fetch_decimal_as_string = false;
@@ -503,6 +504,8 @@ static int Connection_clear(PyObject* self)
 
     Py_XDECREF(cnxn->map_sqltype_to_converter);
     cnxn->map_sqltype_to_converter = 0;
+
+    if (cnxn->bcp) { PyMem_Free(cnxn->bcp); cnxn->bcp = nullptr; }
 
     return 0;
 }
@@ -1529,24 +1532,538 @@ static PyObject* Connection_exit(PyObject* self, PyObject* args)
     Py_RETURN_NONE;
 }
 
+/*=======================================================================================*/
+static const char* BCPCTX_CAPSULE = "pyodbc.BCPContext";
+
+static char bcp_init_doc[] =
+"bcp_init(table, direction=DB_IN, batch_rows=0, keep_nulls=0, hints=None, max_errors=0) -> None\n"
+"\n"
+"Initializes a bulk copy operation for the specified table.\n"
+"\n"
+"Arguments:\n"
+"  table      : Name of the destination table as a string.\n"
+"  direction  : Direction of copy (default: DB_IN for insert).\n"
+"  batch_rows : Number of rows per batch (default: 0 for all in one batch).\n"
+"  keep_nulls : If true, preserves NULLs in the destination table (default: 0).\n"
+"  hints      : Optional string of BCP hints (e.g. 'TABLOCK').\n"
+"  max_errors : Maximum errors allowed before aborting (default: 0).\n"
+"\n"
+"Usage:\n"
+"  conn.bcp_init('dbo.MyTable', keep_nulls=1, hints='TABLOCK', max_errors=10)\n"
+"\n"
+"Note:\n"
+"  This must be called before binding columns or sending rows with BCP.";
+
+static PyObject* Connection_bcp_init(PyObject* oself, PyObject* args, PyObject* kwargs)
+{
+    Connection* self = (Connection*)oself;
+
+    const char* table = nullptr;
+    int direction = DB_IN;  // Default: insert
+    int keep_nulls = 0;
+    const char* hints = NULL;       // UTF-8 string of BCP hints (e.g. \"TABLOCK\")
+    long max_errors = 0;
+    long batch_rows = 0;
+
+    static char* kwlist[] = {"table", "direction", "batch_rows", "keep_nulls", "hints", "max_errors", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|ilizl", kwlist, 
+                                    &table, &direction, &batch_rows, &keep_nulls, &hints, &max_errors))
+    {
+        return 0;
+    }    
+
+    if (!self->hdbc)
+    {
+        PyErr_SetString(ProgrammingError, "The connection is closed.");
+        return 0;
+    }
+    if (!ensure_bcp_loaded(self))
+    {
+        PyErr_SetString(PyExc_NotImplementedError, "BCP functions are not available from the ODBC driver.");
+        return 0;
+    }
+
+    RETCODE ret;
+    Py_BEGIN_ALLOW_THREADS
+    ret = self->bcp->bcp_initA(self->hdbc, (LPCSTR)table, NULL, NULL, direction);
+    Py_END_ALLOW_THREADS
+    if (ret != SUCCEED)
+    {
+        RaiseErrorFromHandle(self, "bcp_init", self->hdbc, SQL_NULL_HANDLE);
+        return 0;
+    }
+
+    // bcp_control is an optional driver export; if it didn't load we cannot
+    // apply any of the options below.  Abort the session we just started and
+    // report rather than dereferencing a null function pointer.
+    if ((batch_rows > 0 || keep_nulls || max_errors > 0 || (hints && *hints))
+        && !self->bcp->bcp_control)
+    {
+        (void)self->bcp->bcp_done(self->hdbc);
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "bcp_control is not available from the ODBC driver; BCP options cannot be set.");
+        return 0;
+    }
+
+    // Set options
+    if (batch_rows > 0)
+    {
+        RETCODE r2;
+        Py_BEGIN_ALLOW_THREADS
+        r2 = self->bcp->bcp_control(self->hdbc, BCPBATCH, (void*)(size_t)batch_rows);
+        Py_END_ALLOW_THREADS
+        if (r2 != SUCCEED)
+        {
+            return RaiseErrorFromHandle(self, "bcp_control(BCPBATCH)", self->hdbc, SQL_NULL_HANDLE);
+        }
+    }
+    if (keep_nulls)
+    {
+        RETCODE r2;
+        Py_BEGIN_ALLOW_THREADS
+        r2 = self->bcp->bcp_control(self->hdbc, BCPKEEPNULLS, (void*)(size_t)1);
+        Py_END_ALLOW_THREADS
+        if (r2 != SUCCEED)
+        {
+            return RaiseErrorFromHandle(self, "bcp_control(BCPKEEPNULLS)", self->hdbc, SQL_NULL_HANDLE);
+        }
+    }
+    if (max_errors > 0)
+    {
+        RETCODE r2;
+        Py_BEGIN_ALLOW_THREADS
+        r2 = self->bcp->bcp_control(self->hdbc, BCPMAXERRS, (void*)(size_t)max_errors);
+        Py_END_ALLOW_THREADS
+        if (r2 != SUCCEED)
+        {
+            return RaiseErrorFromHandle(self, "bcp_control(BCPMAXERRS)", self->hdbc, SQL_NULL_HANDLE);
+        }
+    }
+    if (hints && *hints)
+    {
+        RETCODE r2;
+        Py_BEGIN_ALLOW_THREADS
+        r2 = self->bcp->bcp_control(self->hdbc, BCPHINTS, (void*)hints);
+        Py_END_ALLOW_THREADS
+        if (r2 != SUCCEED)
+        {
+            return RaiseErrorFromHandle(self, "bcp_control(BCPHINTS)", self->hdbc, SQL_NULL_HANDLE);
+        }
+    }
+
+    Py_RETURN_NONE;
+}
+
+static char bcp_bind_columns_doc[] =
+"bcp_bind_columns(types) -> BCPContext\n"
+"\n"
+"Prepares column-wise buffers for high-performance bulk insert using SQL Server BCP.\n"
+"\n"
+"Arguments:\n"
+"  types : Sequence of host types per column (e.g. pyodbc.SQLINT4, pyodbc.SQLFLT8, pyodbc.SQLCHARACTER).\n"
+"\n"
+"Returns:\n"
+"  A BCPContext capsule for use with bcp_setrow(), bcp_sendrow(), and bcp_done().\n"
+"\n"
+"Usage:\n"
+"  ctx = conn.bcp_bind_columns([pyodbc.SQLINT4, pyodbc.SQLCHARACTER])\n"
+"  for row in rows:\n"
+"      conn.bcp_setrow(ctx, row)\n"
+"      conn.bcp_sendrow()\n"
+"  count = conn.bcp_done()\n"
+"\n"
+"Note:\n"
+"  - This function transforms row-wise Python input into column-wise buffers for efficient insertion.\n"
+"  - Variable-length columns (e.g. strings) are handled automatically.\n"
+"  - Only SQLINT4, SQLFLT8, and SQLCHARACTER types are supported (work in progress).";
+
+static PyObject* Connection_bcp_bind_columns(PyObject* oself, PyObject* args, PyObject* kwargs)
+{
+    Connection* self = (Connection*)oself;
+
+    PyObject* types = NULL;
+
+    static char* kwlist[] = {"types", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", kwlist, &types))
+    {
+        return 0;
+    }
+
+    if (!self->hdbc)
+    {
+        PyErr_SetString(ProgrammingError, "The connection is closed.");
+        return 0;
+    }
+
+    if (!ensure_bcp_loaded(self))
+    {
+        PyErr_SetString(PyExc_NotImplementedError, "BCP functions are not available from the ODBC driver.");
+        return 0;
+    }
+
+    if (!PySequence_Check(types))
+    {
+        // Accept general sequences too; make an iterator if needed.
+        PyErr_SetString(PyExc_TypeError, "types must be a sequence of host types per column");
+        return 0;
+    }
+
+    PyObject* types_fast = PySequence_Fast(types, "types must be a sequence");
+    if (!types_fast) return 0;
+
+    const Py_ssize_t ncols = PySequence_Fast_GET_SIZE(types_fast);
+    if (ncols <= 0)
+    {
+        Py_DECREF(types_fast);
+        PyErr_SetString(PyExc_ValueError, "types must not be empty");
+        return 0;
+    
+    }
+
+    // Alocate context and columns
+    BcpCtx* ctx = (BcpCtx*)PyMem_Calloc(1, sizeof(BcpCtx));
+    if (!ctx)
+    {
+        Py_DECREF(types_fast);
+        PyErr_NoMemory();
+        return NULL;
+    }
+    ctx->conn = self; // remember who owns this BCP session (borrowed)
+    ctx->ncols = (int)ncols;
+    ctx->cols = (BcpCol*)PyMem_Calloc((size_t)ncols, sizeof(BcpCol));
+    if (!ctx->cols)
+    {
+        Py_DECREF(types_fast); 
+        PyMem_Free(ctx);
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    // Initialize columns from 'types'
+    for (int i = 0; i < ctx->ncols; ++i)
+    {
+        PyObject* it = PySequence_Fast_GET_ITEM(types_fast, i); // borrowed
+        long t = PyLong_AsLong(it);
+        if (PyErr_Occurred()) 
+        { 
+            Py_DECREF(types_fast); 
+            _bcp_ctx_free(ctx); 
+            return NULL; 
+        }
+
+        BcpCol* c = &ctx->cols[i];
+        c->ordinal = i + 1;
+        c->hostType = (int)t;
+
+        if (t == SQLBIT) {
+            c->isVarLen = 0;
+            c->fixedSize = 1;
+            c->scratchCap = 1;
+        }
+        else if (t == SQLINT2) {
+            c->isVarLen = 0;
+            c->fixedSize = sizeof(short);
+            c->scratchCap = (DBINT)c->fixedSize;
+        }
+        else if (t == SQLINT4)
+        {
+            c->isVarLen = 0;
+            c->fixedSize = sizeof(DBINT);
+            c->scratchCap = (DBINT)c->fixedSize;
+            c->ind = 0;
+        }
+        else if (t == SQLINT8) {
+            c->isVarLen = 0;
+            c->fixedSize = sizeof(long long);
+            c->scratchCap = (DBINT)c->fixedSize;
+        }
+        else if ( t == SQLFLT8)
+        {
+            c->isVarLen = 0;
+            c->fixedSize = sizeof(double);
+            c->scratchCap = (DBINT)c->fixedSize;
+            c->ind = 0;
+        }
+        else if (t == SQLFLT4) {
+            c->isVarLen = 0;
+            c->fixedSize = sizeof(float);
+            c->scratchCap = (DBINT)c->fixedSize;
+        }
+        else if (t == SQLBINARY) {                 // VARBINARY/BINARY
+            c->isVarLen = 1;
+            c->fixedSize = 0;
+            c->scratchCap = 256;                   // grows as needed
+        }
+        else if (t == SQLUNIQUEID) {
+            c->isVarLen = 0;
+            c->fixedSize = 16;
+            c->scratchCap = 16;
+        }
+        else if (t == SQLCHARACTER)
+        {
+            c->isVarLen = 1;
+            c->fixedSize = 0;
+            c->scratchCap = 256; // grows on demand
+            c->ind = SQL_NULL_DATA; // start as NULL
+        }
+        else if (t == SQL_TYPE_TIME) {
+            c->isVarLen = 0;
+            c->fixedSize = sizeof(TIME_STRUCT);
+            c->scratchCap = (DBINT)c->fixedSize;
+        }
+        else
+        {
+            Py_DECREF(types_fast); 
+            PyErr_SetString(PyExc_TypeError, "Unsupported host type in types[]");
+            _bcp_ctx_free(ctx);
+            return NULL;
+        }
+
+        c->scratch = (unsigned char*)PyMem_Malloc(c->scratchCap);
+        if (!c->scratch)
+        {
+            Py_DECREF(types_fast); 
+            PyErr_NoMemory(); 
+            _bcp_ctx_free(ctx);
+            return NULL;
+        }
+    }
+    Py_DECREF(types_fast);
+    
+    // Bind once per column
+    if (!_bcp_bind_all(ctx))
+    {
+        _bcp_ctx_free(ctx);
+        RaiseErrorFromHandle(self, "bcp_bind", self->hdbc, SQL_NULL_HANDLE);
+        return NULL;
+    }
+
+    // Return capsule
+    PyObject* cap = PyCapsule_New(ctx, BCPCTX_CAPSULE, BcpCtx_FreeCapsule);
+    if (!cap)
+    {
+        // PyCapsule_New failed (e.g. OOM); free the context directly rather than
+        // building a second capsule (which could also fail and leak ctx).
+        _bcp_ctx_free(ctx);
+        return NULL;
+    }
+
+    return cap;
+}
+
+static char bcp_setrow_doc[] =
+"bcp_setrow(ctx, row) -> None\n"
+"Populate all bound column buffers from a Python tuple.\n"
+"\n"
+"Each element in 'row' is converted to the corresponding column’s native format\n"
+"and stored in its bound buffer. Use bcp_sendrow() afterward to send the row\n"
+"to the server.\n"
+"\n"
+"Raises:\n"
+"  ValueError: If the BCP context is invalid or belongs to another connection.\n"
+"  TypeError:  If 'row' is not a tuple matching the number of columns.\n"
+"  RuntimeError or OverflowError: On data conversion or binding errors.";
+
+static PyObject* Connection_bcp_setrow(PyObject* oself, PyObject* args) {
+    Connection* self = (Connection*)oself;
+    PyObject* cap = NULL; 
+    PyObject* row = NULL;
+    if (!PyArg_ParseTuple(args, "OO", &cap, &row)) return NULL;
+
+    if (!ensure_bcp_loaded(self)) {
+        PyErr_SetString(PyExc_NotImplementedError, "BCP functions are not available from the ODBC driver.");
+        return NULL;
+    }
+
+    BcpCtx* ctx = (BcpCtx*)PyCapsule_GetPointer(cap, BCPCTX_CAPSULE);
+    if (!ctx) { PyErr_SetString(PyExc_ValueError, "Invalid BCP context"); return NULL; }
+    if (ctx->conn != self) {
+        PyErr_SetString(PyExc_ValueError, "BCP context belongs to a different connection");
+        return NULL;
+    }
+    if (!PyTuple_Check(row) || PyTuple_Size(row) != ctx->ncols) {
+        PyErr_SetString(PyExc_TypeError, "row must be a tuple matching number of columns");
+        return NULL;
+    }
+    for (int c = 0; c < ctx->ncols; ++c) {
+        PyObject* cell = PyTuple_GetItem(row, c);
+        if (!_bcp_fill_cell(ctx, cell, &ctx->cols[c]))
+            return RaiseErrorFromHandle(self, "bcp_collen/bcp conversion", self->hdbc, SQL_NULL_HANDLE);
+    }
+    Py_RETURN_NONE;
+}
+
+static char bcp_sendrow_doc[] =
+"bcp_sendrow() -> None\n"
+"\n"
+"Sends the current bound row to the server using the active BCP context.\n"
+"\n"
+"Call after bcp_setrow() to transmit the row data prepared in bound buffers.\n"
+"\n"
+"Raises:\n"
+"  ProgrammingError: If the connection is closed.\n"
+"  NotImplementedError: If BCP support is unavailable in the ODBC driver.\n"
+"  DatabaseError: If the row send operation fails.";
+
+static PyObject* Connection_bcp_sendrow(PyObject* oself)
+{
+    Connection* self = (Connection*)oself;
+
+    if (!self->hdbc)
+    {
+        PyErr_SetString(ProgrammingError, "The connection is closed.");
+        return 0;
+    }
+    if (!ensure_bcp_loaded(self))
+    {
+        PyErr_SetString(PyExc_NotImplementedError, "BCP functions are not available from the ODBC driver.");
+        return 0;
+    }
+
+
+    RETCODE ret;
+    Py_BEGIN_ALLOW_THREADS
+    ret = self->bcp->bcp_sendrow(self->hdbc);
+    Py_END_ALLOW_THREADS
+
+    if (ret != SUCCEED)
+    {
+        RaiseErrorFromHandle(self, "bcp_sendrow", self->hdbc, SQL_NULL_HANDLE);
+        return 0;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static char bcp_batch_doc[] =
+"bcp_batch([ctx]) -> int\n"
+"\n"
+"Commits all rows sent since the last bcp_batch(), bcp_init(), or bcp_done().\n"
+"Returns the number of rows successfully committed by the driver.\n"
+"If a BCP context is provided, its total committed count is updated.\n"
+"\n"
+"Raises:\n"
+"  ProgrammingError: If the connection is closed.\n"
+"  NotImplementedError: If BCP support is unavailable in the ODBC driver.\n"
+"  ValueError: If the BCP context is invalid or from another connection.\n"
+"  DatabaseError: If the commit operation fails.";
+
+static PyObject* Connection_bcp_batch(PyObject* oself, PyObject* args)
+{
+    Connection* self = (Connection*)oself;
+
+    PyObject* cap = NULL;  // optional BCP context capsule
+    if (!PyArg_ParseTuple(args, "|O", &cap))
+        return NULL;
+
+    if (!self->hdbc)
+    {
+        PyErr_SetString(ProgrammingError, "The connection is closed.");
+        return NULL;
+    }
+
+    if (!ensure_bcp_loaded(self))
+    {
+        PyErr_SetString(PyExc_NotImplementedError, "BCP functions are not available from the ODBC driver.");
+        return NULL;
+    }
+
+    // If a capsule was provided, validate it (but it's fine if not).
+    BcpCtx* ctx = NULL;
+    if (cap && cap != Py_None)
+    {
+        ctx = (BcpCtx*)PyCapsule_GetPointer(cap, BCPCTX_CAPSULE);
+        if (!ctx)
+        {
+            PyErr_SetString(PyExc_ValueError, "Invalid BCP context");
+            return NULL;
+        }
+        // (Optional sanity) ensure the capsule belongs to this connection:
+        if (ctx->conn->hdbc != self->hdbc)
+        {
+            PyErr_SetString(PyExc_ValueError, "BCP context belongs to a different connection");
+            return NULL;
+        }
+    }
+
+    DBINT rc;
+    Py_BEGIN_ALLOW_THREADS
+    rc = self->bcp->bcp_batch(self->hdbc);
+    Py_END_ALLOW_THREADS
+
+    if (rc == -1)
+        return RaiseErrorFromHandle(self, "bcp_batch", self->hdbc, SQL_NULL_HANDLE);
+
+    if (ctx && rc > 0)
+        ctx->total_committed += rc;
+
+    return PyLong_FromLong((long)rc);
+}
+
+static char bcp_done_doc[] =
+"bcp_done() -> int\n"
+"\n"
+"Finalizes the bulk copy (BCP) operation and commits any remaining rows.\n"
+"Returns the total number of rows successfully copied.\n"
+"\n"
+"Raises:\n"
+"  ProgrammingError: If the connection is closed.\n"
+"  NotImplementedError: If BCP support is unavailable in the ODBC driver.\n"
+"  DatabaseError: If the finalization fails.";
+
+static PyObject* Connection_bcp_done(PyObject* oself)
+{
+    Connection* self = (Connection*)oself;
+
+    if (!self->hdbc)
+    {
+        PyErr_SetString(ProgrammingError, "The connection is closed.");
+        return 0;
+    }
+
+    if (!ensure_bcp_loaded(self))
+    {
+        PyErr_SetString(PyExc_NotImplementedError, "BCP functions are not available from the ODBC driver.");
+        return 0;
+    }
+
+    DBINT rows = self->bcp->bcp_done(self->hdbc);
+    if (rows == -1)
+    {
+        RaiseErrorFromHandle(self, "bcp_done", self->hdbc, SQL_NULL_HANDLE);
+        return 0;
+    }
+
+    return PyLong_FromLong(rows);
+}
+
 
 static struct PyMethodDef Connection_methods[] =
 {
-    { "cursor",                  Connection_cursor,          METH_NOARGS,  cursor_doc     },
-    { "close",                   Connection_close,           METH_NOARGS,  close_doc      },
-    { "execute",                 Connection_execute,         METH_VARARGS, execute_doc    },
-    { "commit",                  Connection_commit,          METH_NOARGS,  commit_doc     },
-    { "rollback",                Connection_rollback,        METH_NOARGS,  rollback_doc   },
-    { "getinfo",                 Connection_getinfo,         METH_VARARGS, getinfo_doc    },
-    { "add_output_converter",    Connection_conv_add,        METH_VARARGS, conv_add_doc   },
-    { "remove_output_converter", Connection_conv_remove,     METH_VARARGS, conv_remove_doc },
-    { "get_output_converter",    Connection_conv_get,        METH_VARARGS, conv_get_doc },
-    { "clear_output_converters", Connection_conv_clear,      METH_NOARGS,  conv_clear_doc },
+    { "cursor",                  Connection_cursor,          METH_NOARGS,  cursor_doc       },
+    { "close",                   Connection_close,           METH_NOARGS,  close_doc        },
+    { "execute",                 Connection_execute,         METH_VARARGS, execute_doc      },
+    { "commit",                  Connection_commit,          METH_NOARGS,  commit_doc       },
+    { "rollback",                Connection_rollback,        METH_NOARGS,  rollback_doc     },
+    { "getinfo",                 Connection_getinfo,         METH_VARARGS, getinfo_doc      },
+    { "add_output_converter",    Connection_conv_add,        METH_VARARGS, conv_add_doc     },
+    { "remove_output_converter", Connection_conv_remove,     METH_VARARGS, conv_remove_doc  },
+    { "get_output_converter",    Connection_conv_get,        METH_VARARGS, conv_get_doc     },
+    { "clear_output_converters", Connection_conv_clear,      METH_NOARGS,  conv_clear_doc   },
     { "setdecoding",             (PyCFunction)Connection_setdecoding,     METH_VARARGS|METH_KEYWORDS, setdecoding_doc },
     { "setencoding",             (PyCFunction)Connection_setencoding,     METH_VARARGS|METH_KEYWORDS, 0 },
     { "set_attr",                Connection_set_attr,        METH_VARARGS, set_attr_doc   },
     { "__enter__",               Connection_enter,           METH_NOARGS,  enter_doc      },
     { "__exit__",                Connection_exit,            METH_VARARGS, exit_doc       },
+    { "bcp_init",                (PyCFunction)Connection_bcp_init,      METH_VARARGS|METH_KEYWORDS, bcp_init_doc },
+    { "bcp_bind_columns",        (PyCFunction)Connection_bcp_bind_columns, METH_VARARGS|METH_KEYWORDS, bcp_bind_columns_doc },
+    { "bcp_setrow",              (PyCFunction)Connection_bcp_setrow,    METH_VARARGS, bcp_setrow_doc    },
+    { "bcp_sendrow",             (PyCFunction)Connection_bcp_sendrow,   METH_NOARGS,  bcp_sendrow_doc   },
+    { "bcp_batch",               (PyCFunction)Connection_bcp_batch,     METH_VARARGS, bcp_batch_doc     },
+    { "bcp_done",                (PyCFunction)Connection_bcp_done,      METH_NOARGS,  bcp_done_doc      },
+
 
     { 0, 0, 0, 0 }
 };

--- a/src/connection.h
+++ b/src/connection.h
@@ -12,6 +12,8 @@
 #ifndef CONNECTION_H
 #define CONNECTION_H
 
+struct BcpProcs;
+
 struct Cursor;
 
 extern PyTypeObject ConnectionType;
@@ -31,6 +33,11 @@ struct Connection
     // The ODBC version the driver supports, from SQLGetInfo(DRIVER_ODBC_VER).  This is set after connecting.
     char odbc_major;
     char odbc_minor;
+
+    // BCP support, loaded on demand.
+    // If bcp.loaded is false, BCP is not supported.
+    // If bcp.loaded is true, all function pointers are valid.
+    BcpProcs* bcp;
 
     // The escape character from SQLGetInfo.  This is not initialized until requested, so this may be zero!
     PyObject* searchescape;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -1123,6 +1123,25 @@ static PyObject* Cursor_executemany(PyObject* self, PyObject* args)
         if (cursor->fastexecmany)
         {
             free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
+            // Prefer the BCP fast path if BCP is enabled.
+            // If BCP is not handled properly, fall back to the standard execute-many path.
+            // If BCP is handled but errors occur, finalize and propagate the errors.
+            // If BCP completes successfully, return None.
+            if (cursor->use_bcp_fast)
+            {
+                bool bcp_ok = ExecuteMulti_BCP(cursor, pSql, param_seq);
+                if (bcp_ok)
+                {
+                    if (PyErr_Occurred())
+                        return NULL;
+                    cursor->rowcount = -1;
+                    Py_RETURN_NONE;
+                }
+                if (PyErr_Occurred())
+                    return 0;
+                // ExecuteMulti_BCP returned false: BCP isn't usable for this
+                // statement (e.g. not a parseable INSERT) -- fall back below.
+            }
             if (!ExecuteMulti(cursor, pSql, param_seq))
                 return 0;
         }
@@ -2520,6 +2539,9 @@ static PyMemberDef Cursor_members[] =
     {"fast_executemany",T_BOOL,  offsetof(Cursor, fastexecmany),    0,        fastexecmany_doc },
     {"messages",    T_OBJECT_EX, offsetof(Cursor, messages),        READONLY, messages_doc },
     {"rows_as_dicts", T_BOOL,    offsetof(Cursor, rows_as_dicts),   0,        rowsasdicts_doc },
+    {"use_bcp_fast", T_BOOL,     offsetof(Cursor, use_bcp_fast), 0, "Prefer BCP for fast_executemany" },
+    {"bcp_batch_rows", T_LONG,   offsetof(Cursor, bcp_batch_rows), 0, "Number of rows per batch when using BCP" },
+    {"bcp_tablock",  T_BOOL,     offsetof(Cursor, bcp_tablock), 0, "Pass the TABLOCK hint when using BCP (enables minimal logging)" },
     { 0 }
 };
 
@@ -2825,6 +2847,9 @@ Cursor_New(Connection* cnxn)
         cur->fastexecmany      = 0;
         cur->rows_as_dicts     = 0;
         cur->messages          = Py_None;
+        cur->use_bcp_fast      = false;
+        cur->bcp_batch_rows    = 0;
+        cur->bcp_tablock       = false;
 
         Py_INCREF(cnxn);
         Py_INCREF(cur->description);

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -98,6 +98,16 @@ struct Cursor
     // Set to SQL_NULL_HANDLE when the cursor is closed.
     HSTMT hstmt;
 
+    // If true, fast executemany will default to using BCP if available.
+    bool use_bcp_fast = false;
+    
+    // BCP configuration
+    long bcp_batch_rows = 0;            // amount of rows per batch, 0 means driver default (no batching)
+
+    // If true, the BCP fast path passes the TABLOCK hint, which enables a bulk-update
+    // lock and (with a SIMPLE/BULK_LOGGED recovery model + heap) minimal logging.
+    bool bcp_tablock = false;
+
     //
     // SQL Parameters
     //

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -24,7 +24,7 @@
 #include "dbspecific.h"
 #include "row.h"
 #include <datetime.h>
-
+#include "bcp_support.h"
 
 inline Connection* GetConnection(Cursor* cursor)
 {
@@ -1958,6 +1958,591 @@ bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj)
   return ret;
 }
 
+bool ExecuteMulti_BCP(Cursor* cur, PyObject* pSql, PyObject* param_seq)
+{
+    if (!cur || !cur->cnxn || !cur->cnxn->hdbc || !cur->use_bcp_fast)
+        return false;
+
+    if (!PyUnicode_Check(pSql))
+        return false;
+
+    Py_ssize_t sql_len = 0;
+    const char* sql = PyUnicode_AsUTF8AndSize(pSql, &sql_len);
+    if (!sql || sql_len <= 0)
+        return false;
+
+    char tableref[512] = {0};   // verbatim "[schema.]table" for bcp_init
+    char ins_schema[256] = {0};
+    char ins_table[256] = {0};
+    char** col_names = NULL;     // explicit column list (NULL if none)
+    int    n_col_names = 0;
+    if (!parse_insert_target(sql, tableref, (int)sizeof(tableref),
+                             ins_schema, (int)sizeof(ins_schema),
+                             ins_table, (int)sizeof(ins_table),
+                             &col_names, &n_col_names))
+        return false;   // not a BCP-able INSERT (caller handles any PyErr)
+
+    Connection* cn = cur->cnxn;
+
+    // Ensure BCP exports loaded
+    if (!cn->bcp || !cn->bcp->loaded) {
+        if (!cn->bcp) {
+            cn->bcp = (BcpProcs*)PyMem_Calloc(1, sizeof(BcpProcs));
+            if (!cn->bcp) { bcp_free_names(col_names, n_col_names); PyErr_NoMemory(); return true; }
+        }
+        if (!BcpLoadFromDriver(cn->hdbc, *cn->bcp)) {
+            bcp_free_names(col_names, n_col_names);
+            return false; // fall back
+        }
+    }
+    // NOTE: bcp_init is deferred until after the rows are validated and the
+    // column buffers are allocated (just before the bind loop). That way every
+    // early "fall back" path below returns without leaving an open bulk-copy
+    // session on the connection. col_names (if any) is freed once the column
+    // ordinals have been resolved, just before the bind loop.
+    PyObject* iter = PyObject_GetIter(param_seq);
+    if (!iter) { PyErr_Clear(); bcp_free_names(col_names, n_col_names); return false; }
+
+    PyObject* first = PyIter_Next(iter);
+    if (!first) {
+        // No rows: nothing to insert, and no BCP session has been started.
+        bcp_free_names(col_names, n_col_names);
+        Py_DECREF(iter);
+        cur->rowcount = 0;
+        return true;
+    }
+    if (!PyTuple_Check(first)) { bcp_free_names(col_names, n_col_names); Py_DECREF(first); Py_DECREF(iter); return false; }
+
+    const Py_ssize_t ncols = PyTuple_Size(first);
+    if (ncols <= 0) { bcp_free_names(col_names, n_col_names); Py_DECREF(first); Py_DECREF(iter); return false; }
+
+    // If an explicit column list was given it must match the row arity.
+    if (n_col_names > 0 && (int)ncols != n_col_names) {
+        bcp_free_names(col_names, n_col_names); Py_DECREF(first); Py_DECREF(iter);
+        return false;   // arity mismatch -> fall back to the normal path
+    }
+
+    // --- Deduce host types from first row -----------------------------------
+    int* types = (int*)PyMem_Malloc(sizeof(int) * (size_t)ncols);
+    if (!types) { bcp_free_names(col_names, n_col_names); Py_DECREF(first); Py_DECREF(iter); PyErr_NoMemory(); return true; }
+
+    auto fits_int32 = [](long long v) -> bool {
+        return (v >= -2147483648LL && v <= 2147483647LL);
+    };
+
+    for (Py_ssize_t i = 0; i < ncols; ++i) {
+        PyObject* cell = PyTuple_GetItem(first, i); // borrowed
+        PyObject* dec_cls = 0;
+
+        if (cell == Py_None) {
+            // Safe generic default: send as text (server will convert)
+            types[i] = SQLCHARACTER;
+        }
+
+        // bool BEFORE int (bool is subclass of int)
+        else if (PyBool_Check(cell)) { types[i] = SQLBIT; }
+
+        else if (PyLong_Check(cell)) {
+            long long lv = PyLong_AsLongLong(cell);
+            if (PyErr_Occurred()) { PyErr_Clear(); bcp_free_names(col_names, n_col_names); PyMem_Free(types); Py_DECREF(first); Py_DECREF(iter); return false; }
+            types[i] = fits_int32(lv) ? SQLINT4 : SQLINT8;
+        }
+
+        else if (PyFloat_Check(cell)) { types[i] = SQLFLT8; }
+
+        // Temporal types are sent as ISO text for now. The native length-prefixed
+        // binary path (SQLDATEN/SQLTIMEN/SQLDATETIME2N/SQLDATETIMEOFFSETN, see the
+        // SQL*N cases in fill_cell) binds successfully, but bcp_sendrow rejects
+        // sub-second values: bcp_bind carries no fractional-second scale, so the
+        // driver assumes scale 0 and reports "Fractional second precision exceeds
+        // the scale specified in the parameter binding." Enabling native binary
+        // needs the destination column's scale conveyed to BCP -- deferred.
+        else if (PyTime_Check(cell)) {
+            types[i] = SQLCHARACTER;
+        }
+        else if (IsInstanceForThread(cell, "decimal", "Decimal", &dec_cls) && dec_cls) {
+            Py_DECREF(dec_cls);
+            types[i] = SQLCHARACTER; // send as text like base path
+        }
+        else if (PyUnicode_Check(cell) || PyBytes_Check(cell) || PyByteArray_Check(cell)) {
+            types[i] = SQLCHARACTER;
+        }
+        else if (PyDateTime_Check(cell)) {
+            types[i] = SQLCHARACTER;
+        }
+        else if (PyDate_Check(cell)) {
+            types[i] = SQLCHARACTER;
+        }
+        else {
+            // Unknown type
+            bcp_free_names(col_names, n_col_names); PyMem_Free(types); Py_DECREF(first); Py_DECREF(iter);
+            return false;
+        }
+    }
+    // --- Build BCP context (column-wise) ------------------------------------
+    BcpCtx* ctx = (BcpCtx*)PyMem_Calloc(1, sizeof(BcpCtx));
+    if (!ctx) { bcp_free_names(col_names, n_col_names); PyMem_Free(types); Py_DECREF(first); Py_DECREF(iter); PyErr_NoMemory(); return true; }
+
+    ctx->conn  = cn;
+    ctx->ncols = (int)ncols;
+    ctx->cols  = (BcpCol*)PyMem_Calloc((size_t)ncols, sizeof(BcpCol));
+    if (!ctx->cols) { bcp_free_names(col_names, n_col_names); PyMem_Free(ctx); PyMem_Free(types); Py_DECREF(first); Py_DECREF(iter); PyErr_NoMemory(); return true; }
+
+    for (int i = 0; i < ctx->ncols; ++i) {
+        BcpCol* c = &ctx->cols[i];
+        c->ordinal  = i + 1;
+        c->hostType = types[i];
+
+        switch (types[i]) {
+        case SQLINT4:       { c->isVarLen=0; c->fixedSize=sizeof(DBINT);     c->scratchCap=(DBINT)c->fixedSize; c->ind=0; break; }
+        case SQLINT8:       { c->isVarLen=0; c->fixedSize=sizeof(long long); c->scratchCap=(DBINT)c->fixedSize; c->ind=0; break; }
+        case SQLBIT:        { c->isVarLen=0; c->fixedSize=1;                 c->scratchCap=(DBINT)c->fixedSize; c->ind=0; break; }
+        case SQLFLT8:       { c->isVarLen=0; c->fixedSize=sizeof(double);    c->scratchCap=(DBINT)c->fixedSize; c->ind=0; break; }
+        // Temporal types are bound length-prefixed (isVarLen=1): a 4-byte length
+        // prefix precedes the raw TDS value bytes in the scratch buffer.
+        case SQLTIMEN:      { c->isVarLen=1; c->fixedSize=5;                 c->scratchCap=4+5;                 c->ind=0; break; } // time(7): 5 bytes
+        case SQLDATEN:      { c->isVarLen=1; c->fixedSize=3;                 c->scratchCap=4+3;                 c->ind=0; break; } // days since 0001-01-01
+        case SQLDATETIME2N: { c->isVarLen=1; c->fixedSize=8;                 c->scratchCap=4+8;                 c->ind=0; break; } // 5 (time) + 3 (date) at scale 7
+        case SQLDATETIMEOFFSETN: { c->isVarLen=1; c->fixedSize=10;           c->scratchCap=4+10;                c->ind=0; break; } // 5 + 3 + 2
+        default:            { c->isVarLen=1; c->fixedSize=0;  c->scratchCap=4+256; c->ind=SQL_NULL_DATA; c->hostType=SQLCHARACTER; break; } // CHARACTER: 4-byte length prefix + data
+        }
+
+        c->scratch = (unsigned char*)PyMem_Malloc(c->scratchCap);
+        if (!c->scratch) {
+            for (int k = 0; k < i; ++k) PyMem_Free(ctx->cols[k].scratch);
+            bcp_free_names(col_names, n_col_names);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx); PyMem_Free(types); Py_DECREF(first); Py_DECREF(iter);
+            PyErr_NoMemory(); return true;
+        }
+    }
+    PyMem_Free(types);
+
+    // Map an explicit column list to table ordinals (BCP binds by ordinal).
+    // Without a list the positional ordinals assigned above (1..N) are used.
+    if (n_col_names > 0) {
+        int* ord = (int*)PyMem_Malloc(sizeof(int) * (size_t)n_col_names);
+        int ok = 0, total = 0;
+        if (ord) {
+            ok = bcp_resolve_ordinals(cn->hdbc, ins_schema, ins_table, col_names, n_col_names, ord, &total);
+            // BCP must bind every column; a partial list would leave the unlisted
+            // columns unbound (and binding them NULL would override their
+            // DEFAULTs), so fall back to the normal path for a column subset.
+            if (ok && total > 0 && n_col_names != total) ok = 0;
+            if (ok) for (int i = 0; i < ctx->ncols; ++i) ctx->cols[i].ordinal = ord[i];
+            PyMem_Free(ord);
+        } else {
+            PyErr_NoMemory();
+        }
+        if (!ok) {
+            int was_oom = (ord == NULL);
+            bcp_free_names(col_names, n_col_names); col_names = NULL;
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            Py_DECREF(first); Py_DECREF(iter);
+            return was_oom ? true : false;   // OOM -> propagate; otherwise fall back
+        }
+    }
+    bcp_free_names(col_names, n_col_names);
+    col_names = NULL;
+
+    // Start the BCP session now that the rows validate and buffers exist. From
+    // here on, any error must call bcp_done to close/abort the session, or the
+    // connection is left mid-bulk-copy and the next operation fails.
+    {
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = cn->bcp->bcp_initA(cn->hdbc, tableref, nullptr, nullptr, DB_IN);
+        Py_END_ALLOW_THREADS
+        if (rc != SUCCEED) {
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            RaiseErrorFromHandle(cn, "bcp_init", cn->hdbc, SQL_NULL_HANDLE);
+            Py_DECREF(first); Py_DECREF(iter);
+            return true;
+        }
+    }
+    if (cur->bcp_batch_rows > 0 && cn->bcp->bcp_control) {
+        SQLRETURN r2;
+        Py_BEGIN_ALLOW_THREADS
+        r2 = cn->bcp->bcp_control(cn->hdbc, BCPBATCH, (void*)(size_t)cur->bcp_batch_rows);
+        Py_END_ALLOW_THREADS
+        if (r2 != SUCCEED) {
+            (void)cn->bcp->bcp_done(cn->hdbc);
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            RaiseErrorFromHandle(cn, "bcp_control(BCPBATCH)", cn->hdbc, SQL_NULL_HANDLE);
+            Py_DECREF(first); Py_DECREF(iter);
+            return true;
+        }
+    }
+    // TABLOCK hint: enables a bulk-update lock on the destination and, when the
+    // database is in SIMPLE/BULK_LOGGED recovery and the target is a heap, allows
+    // minimal logging -- the primary source of BCP's speed advantage.
+    if (cur->bcp_tablock && cn->bcp->bcp_control) {
+        SQLRETURN r2;
+        Py_BEGIN_ALLOW_THREADS
+        r2 = cn->bcp->bcp_control(cn->hdbc, BCPHINTS, (void*)"TABLOCK");
+        Py_END_ALLOW_THREADS
+        if (r2 != SUCCEED) {
+            (void)cn->bcp->bcp_done(cn->hdbc);
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            RaiseErrorFromHandle(cn, "bcp_control(BCPHINTS)", cn->hdbc, SQL_NULL_HANDLE);
+            Py_DECREF(first); Py_DECREF(iter);
+            return true;
+        }
+    }
+
+    // Bind columns
+    for (int i = 0; i < ctx->ncols; ++i) {
+        BcpCol* c = &ctx->cols[i];
+        // Variable-length columns need a length prefix (cbIndicator) at bind time;
+        // we use a 4-byte prefix and write the per-row length into the buffer.
+        // Fixed columns use no prefix and bind their exact byte size.
+        const DBINT cbIndicator = c->isVarLen ? 4 : 0;
+        const DBINT cbData      = c->isVarLen ? SQL_VARLEN_DATA : (DBINT)c->fixedSize;
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = cn->bcp->bcp_bind(cn->hdbc, (LPCBYTE)c->scratch, cbIndicator, cbData, nullptr, 0, c->hostType, c->ordinal);
+        Py_END_ALLOW_THREADS
+        if (rc != SUCCEED) {
+            (void)cn->bcp->bcp_done(cn->hdbc);
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            RaiseErrorFromHandle(cn, "bcp_bind", cn->hdbc, SQL_NULL_HANDLE);
+            Py_DECREF(first); Py_DECREF(iter);
+            return true;
+        }
+    }
+    // For a fixed-width column the length is established once by bcp_bind, so we
+    // only need to call bcp_collen when the previous row for this column was NULL
+    // (to clear the NULL indicator). This removes one driver call per fixed cell
+    // per row on the common all-non-NULL path.
+    auto fixed_len_ok = [&](BcpCol* c, DBINT len) -> int {
+        if (c->was_null) {
+            if (cn->bcp->bcp_collen(cn->hdbc, len, c->ordinal) == FAIL)
+                return 0;
+            c->was_null = false;
+        }
+        return 1;
+    };
+
+    // Variable-length columns are bound with a 4-byte little-endian length
+    // prefix (cbIndicator=4) because the driver requires a prefix or terminator
+    // at bind time. The scratch buffer layout is [4-byte length][data...]; a
+    // prefix value of -1 (0xFFFFFFFF) marks SQL NULL. This avoids per-row
+    // bcp_collen calls for varlen columns.
+    const DBINT VARLEN_PREFIX = 4;
+    auto put_varlen = [&](BcpCol* c, const char* p, Py_ssize_t n) -> int {
+        DBINT need = (DBINT)(VARLEN_PREFIX + n);
+        if (need > c->scratchCap) {
+            unsigned char* np = (unsigned char*)PyMem_Realloc(c->scratch, (size_t)need);
+            if (!np) { PyErr_NoMemory(); return 0; }
+            c->scratch = np; c->scratchCap = need;
+            if (cn->bcp->bcp_bind(cn->hdbc, (LPCBYTE)c->scratch, VARLEN_PREFIX, SQL_VARLEN_DATA, nullptr, 0, c->hostType, c->ordinal) != SUCCEED)
+                return 0;
+        }
+        write_le(c->scratch, (unsigned long long)(unsigned int)n, VARLEN_PREFIX);
+        if (n > 0) memcpy(c->scratch + VARLEN_PREFIX, p, (size_t)n);
+        return 1;
+    };
+
+    // Fill helpers (Option B structs for date/time/datetime)
+    auto fill_cell = [&](PyObject* cell, BcpCol* c) -> int {
+        if (cell == Py_None) {
+            if (c->isVarLen) {
+                // NULL via length prefix = -1 (no bcp_collen needed).
+                write_le(c->scratch, 0xFFFFFFFFULL, VARLEN_PREFIX);
+                return 1;
+            }
+            if (cn->bcp->bcp_collen(cn->hdbc, SQL_NULL_DATA, c->ordinal) == FAIL)
+                return 0;
+            c->was_null = true;
+            return 1;
+        }
+
+        switch (c->hostType) {
+        case SQLBIT: {
+            unsigned char b = (unsigned char)(PyObject_IsTrue(cell) ? 1 : 0);
+            memcpy(c->scratch, &b, 1);
+            return fixed_len_ok(c, 1);
+        }
+        case SQLINT4: {
+            long long lv = PyLong_AsLongLong(cell);
+            if (PyErr_Occurred()) return 0;
+            if (lv < -2147483648LL || lv > 2147483647LL) {
+                // The column type was deduced INT from the first row; a later
+                // value that doesn't fit must not be silently truncated.
+                PyErr_SetString(PyExc_OverflowError, "INTEGER value out of range for BCP column");
+                return 0;
+            }
+            DBINT v = (DBINT)lv;
+            memcpy(c->scratch, &v, sizeof(DBINT));
+            return fixed_len_ok(c, (DBINT)sizeof(DBINT));
+        }
+        case SQLINT8: {
+            long long v = PyLong_AsLongLong(cell);
+            if (PyErr_Occurred()) return 0;
+            memcpy(c->scratch, &v, sizeof(long long));
+            return fixed_len_ok(c, (DBINT)sizeof(long long));
+        }
+        case SQLFLT8: {
+            double d = PyFloat_AsDouble(cell);
+            if (PyErr_Occurred()) return 0;
+            memcpy(c->scratch, &d, sizeof(double));
+            return fixed_len_ok(c, (DBINT)sizeof(double));
+        }
+        case SQLTIMEN: {  // time(7): 5 bytes, length-prefixed
+            int hh = PyDateTime_TIME_GET_HOUR(cell);
+            int mm = PyDateTime_TIME_GET_MINUTE(cell);
+            int ss = PyDateTime_TIME_GET_SECOND(cell);
+            int mu = PyDateTime_TIME_GET_MICROSECOND(cell);
+            unsigned long long ticks = time_to_ticks7(hh, mm, ss, mu);
+            unsigned char tmp[5];
+            write_le(tmp, ticks, 5);
+            return put_varlen(c, (const char*)tmp, 5);
+        }
+        case SQLDATETIMEOFFSETN: {  // datetimeoffset(7): 10 bytes, length-prefixed
+            // Extract local wall time components
+            int y  = PyDateTime_GET_YEAR(cell);
+            int m  = PyDateTime_GET_MONTH(cell);
+            int d  = PyDateTime_GET_DAY(cell);
+            int hh = PyDateTime_DATE_GET_HOUR(cell);
+            int mm = PyDateTime_DATE_GET_MINUTE(cell);
+            int ss = PyDateTime_DATE_GET_SECOND(cell);
+            int mu = PyDateTime_DATE_GET_MICROSECOND(cell);
+
+            // Offset in minutes (signed)
+            PyObject* delta = PyObject_CallMethod(cell, "utcoffset", 0);
+            if (!delta || delta == Py_None) { Py_XDECREF(delta); PyErr_SetString(PyExc_ValueError, "datetimeoffset requires tz-aware datetime"); return 0; }
+            long days = PyDateTime_DELTA_GET_DAYS(delta);
+            long secs = PyDateTime_DELTA_GET_SECONDS(delta);
+            long usec = PyDateTime_DELTA_GET_MICROSECONDS(delta);
+            Py_DECREF(delta);
+
+            // Fractional offset smaller than a minute is not representable; require whole minutes
+            if (usec % 60000000 != 0 || (secs % 60) != 0) {
+                PyErr_SetString(PyExc_ValueError, "datetimeoffset offset must be minute-aligned");
+                return 0;
+            }
+            long offset_minutes = days * 1440 + (secs / 60);
+            if (offset_minutes < -14*60 || offset_minutes > 14*60) {
+                PyErr_SetString(PyExc_ValueError, "datetimeoffset out of range (-14:00 to +14:00)");
+                return 0;
+            }
+
+            unsigned long long ticks = time_to_ticks7(hh, mm, ss, mu);
+            unsigned int days_ce = days_since_0001_01_01(y, m, d);
+
+            unsigned char tmp[10];
+            write_le(tmp + 0,  ticks, 5);
+            write_le(tmp + 5,  days_ce, 3);
+            // offset as signed 16-bit minutes, little-endian
+            short off = (short)offset_minutes;
+            memcpy(tmp + 8, &off, 2);
+            return put_varlen(c, (const char*)tmp, 10);
+        }
+        case SQLDATEN:   // date only: 3 bytes, length-prefixed
+        {
+            int y = PyDateTime_GET_YEAR(cell);
+            int m = PyDateTime_GET_MONTH(cell);
+            int d = PyDateTime_GET_DAY(cell);
+            unsigned int days_ce = days_since_0001_01_01(y, m, d);
+            unsigned char tmp[3];
+            write_le(tmp, days_ce, 3);
+            return put_varlen(c, (const char*)tmp, 3);
+        }
+        case SQLDATETIME2N:   // datetime2(7): 8 bytes, length-prefixed
+        {
+            int y = PyDateTime_GET_YEAR(cell);
+            int m = PyDateTime_GET_MONTH(cell);
+            int d = PyDateTime_GET_DAY(cell);
+            int hh = PyDateTime_DATE_GET_HOUR(cell);
+            int mm = PyDateTime_DATE_GET_MINUTE(cell);
+            int ss = PyDateTime_DATE_GET_SECOND(cell);
+            int mu = PyDateTime_DATE_GET_MICROSECOND(cell);
+
+            unsigned long long ticks = time_to_ticks7(hh, mm, ss, mu);
+            unsigned int days_ce = days_since_0001_01_01(y, m, d);
+
+            // datetime2(7) = 5-byte time ticks + 3-byte days (little-endian both)
+            unsigned char tmp[8];
+            write_le(tmp + 0, ticks, 5);
+            write_le(tmp + 5, days_ce, 3);
+            return put_varlen(c, (const char*)tmp, 8);
+        }
+        default: {
+            // SQLCHARACTER (varlen)
+            const char* p = NULL; Py_ssize_t n = 0;
+
+            PyObject* dec_cls = 0;
+            // Prefer ISO for date/time family (works for datetime, date, time, and tz-aware)
+            if (PyDateTime_Check(cell) || PyDate_Check(cell) || PyTime_Check(cell)) {
+                // datetime/date/time all support .isoformat(); for datetime use space separator
+                PyObject* s = PyDateTime_Check(cell)
+                                ? PyObject_CallMethod(cell, "isoformat", "s", " ")
+                                : PyObject_CallMethod(cell, "isoformat", NULL);
+                if (!s) return 0;
+                p = PyUnicode_AsUTF8AndSize(s, &n);
+                if (!p) { Py_DECREF(s); return 0; }
+                int ok = put_varlen(c, p, n);
+                Py_DECREF(s);
+                return ok;
+            }
+            if (IsInstanceForThread(cell, "decimal", "Decimal", &dec_cls) && dec_cls) {
+                Py_DECREF(dec_cls);
+                // Build canonical ASCII (no exponent), same as base path
+                PyObject* t = PyObject_CallMethod(cell, "as_tuple", 0);
+                if (!t) return 0;
+
+                long sign = PyLong_AsLong(PyTuple_GET_ITEM(t, 0));
+                PyObject* digits = PyTuple_GET_ITEM(t, 1);
+                long exp = PyLong_AsLong(PyTuple_GET_ITEM(t, 2));
+                // Non-finite Decimals (NaN/Infinity) have a non-integer exponent
+                // ('n'/'N'/'F'); reject them rather than fabricate a string.
+                if (PyErr_Occurred()) { Py_DECREF(t); return 0; }
+
+                char* s = CreateDecimalString(sign, digits, exp);  // uses PyMem_Malloc
+                Py_DECREF(t);
+                if (!s) { PyErr_NoMemory(); return 0; }
+
+                n = (Py_ssize_t)strlen(s);
+                int ok = put_varlen(c, s, n);
+                PyMem_Free(s);
+                return ok;
+            }
+
+            if (PyUnicode_Check(cell)) {
+                p = PyUnicode_AsUTF8AndSize(cell, &n);
+                if (!p) return 0;
+            } else if (PyBytes_Check(cell)) {
+                p = PyBytes_AsString(cell);
+                if (!p) return 0;
+                n = PyBytes_GET_SIZE(cell);
+            } else if (PyByteArray_Check(cell)) {
+                p = PyByteArray_AsString(cell);
+                n = PyByteArray_Size(cell);
+            } else {
+                PyErr_SetString(PyExc_TypeError, "Expected str/bytes/bytearray");
+                return 0;
+            }
+            return put_varlen(c, p, n);
+        }}
+    };
+
+    auto send_row = [&]() -> int {
+        SQLRETURN rc;
+        Py_BEGIN_ALLOW_THREADS
+        rc = cn->bcp->bcp_sendrow(cn->hdbc);
+        Py_END_ALLOW_THREADS
+        return (rc == SUCCEED);
+    };
+
+    // first row
+    for (int i = 0; i < ctx->ncols; ++i) {
+        PyObject* cell = PyTuple_GetItem(first, i);
+        if (!fill_cell(cell, &ctx->cols[i])) {
+            // fill_cell may already have set a Python exception (e.g. overflow);
+            // only fall back to the ODBC diagnostic if it didn't.
+            if (!PyErr_Occurred())
+                RaiseErrorFromHandle(cn, "bcp_collen/bcp conversion", cn->hdbc, SQL_NULL_HANDLE);
+            (void)cn->bcp->bcp_done(cn->hdbc);
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            Py_DECREF(first); Py_DECREF(iter);
+            return true;
+        }
+    }
+    Py_DECREF(first);
+    if (!send_row()) {
+        (void)cn->bcp->bcp_done(cn->hdbc);
+        for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+        PyMem_Free(ctx->cols); PyMem_Free(ctx); Py_DECREF(iter);
+        RaiseErrorFromHandle(cn, "bcp_sendrow", cn->hdbc, SQL_NULL_HANDLE);
+        return true;
+    }
+
+    // remaining rows (+ optional manual batching)
+    DBINT total_committed = 0;
+    DBINT since_last_batch = 0;
+    PyObject* row = nullptr;
+    while ((row = PyIter_Next(iter)) != nullptr) {
+        if (!PyTuple_Check(row) || PyTuple_Size(row) != ncols) {
+            (void)cn->bcp->bcp_done(cn->hdbc);
+            Py_DECREF(row); Py_DECREF(iter);
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            PyErr_SetString(PyExc_TypeError, "Row must be a tuple matching first row arity");
+            return true;
+        }
+        for (int i = 0; i < ctx->ncols; ++i) {
+            PyObject* cell = PyTuple_GetItem(row, i);
+            if (!fill_cell(cell, &ctx->cols[i])) {
+                if (!PyErr_Occurred())
+                    RaiseErrorFromHandle(cn, "bcp_collen/bcp conversion", cn->hdbc, SQL_NULL_HANDLE);
+                (void)cn->bcp->bcp_done(cn->hdbc);
+                Py_DECREF(row); Py_DECREF(iter);
+                for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+                PyMem_Free(ctx->cols); PyMem_Free(ctx);
+                return true;
+            }
+        }
+        Py_DECREF(row);
+        if (!send_row()) {
+            (void)cn->bcp->bcp_done(cn->hdbc);
+            Py_DECREF(iter);
+            for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+            PyMem_Free(ctx->cols); PyMem_Free(ctx);
+            RaiseErrorFromHandle(cn, "bcp_sendrow", cn->hdbc, SQL_NULL_HANDLE);
+            return true;
+        }
+
+        if (cur->bcp_batch_rows > 0 && cn->bcp->bcp_batch) {
+            since_last_batch++;
+            if (since_last_batch >= (DBINT)cur->bcp_batch_rows) {
+                DBINT rc;
+                Py_BEGIN_ALLOW_THREADS
+                rc = cn->bcp->bcp_batch(cn->hdbc);
+                Py_END_ALLOW_THREADS
+                if (rc == FAIL) {
+                    (void)cn->bcp->bcp_done(cn->hdbc);
+                    Py_DECREF(iter);
+                    for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+                    PyMem_Free(ctx->cols); PyMem_Free(ctx);
+                    RaiseErrorFromHandle(cn, "bcp_batch", cn->hdbc, SQL_NULL_HANDLE);
+                    return true;
+                }
+                if (rc > 0) total_committed += rc;
+                since_last_batch = 0;
+            }
+        }
+    }
+    Py_DECREF(iter);
+    if (PyErr_Occurred()) {
+        // PyIter_Next raised mid-iteration; abort the bulk-copy session.
+        (void)cn->bcp->bcp_done(cn->hdbc);
+        for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+        PyMem_Free(ctx->cols); PyMem_Free(ctx);
+        return true;
+    }
+    // done
+    DBINT done_rows;
+    Py_BEGIN_ALLOW_THREADS
+    done_rows = cn->bcp->bcp_done(cn->hdbc);
+    Py_END_ALLOW_THREADS
+    if (done_rows == -1) {
+        for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+        PyMem_Free(ctx->cols); PyMem_Free(ctx);
+        RaiseErrorFromHandle(cn, "bcp_done", cn->hdbc, SQL_NULL_HANDLE);
+        return true;
+    }
+    
+    cur->rowcount = (int)(total_committed + done_rows);
+
+    for (int k = 0; k < ctx->ncols; ++k) PyMem_Free(ctx->cols[k].scratch);
+    PyMem_Free(ctx->cols); PyMem_Free(ctx);
+    return true;
+}
 
 static bool GetParamType(Cursor* cur, Py_ssize_t index, SQLSMALLINT& type)
 {

--- a/src/params.h
+++ b/src/params.h
@@ -8,6 +8,7 @@ struct Cursor;
 
 bool PrepareAndBind(Cursor* cur, PyObject* pSql, PyObject* params, bool skip_first);
 bool ExecuteMulti(Cursor* cur, PyObject* pSql, PyObject* paramArrayObj);
+bool ExecuteMulti_BCP(Cursor* cur, PyObject* pSql, PyObject* param_seq);
 bool GetParameterInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo& info, bool isTVP);
 void FreeParameterData(Cursor* cur);
 void FreeParameterInfo(Cursor* cur);

--- a/tests/sqlserver_test.py
+++ b/tests/sqlserver_test.py
@@ -8,7 +8,7 @@ import re
 import uuid
 from collections.abc import Iterator
 from decimal import Decimal
-from datetime import date, time, datetime
+from datetime import date, time, datetime, timedelta, timezone
 from functools import lru_cache
 
 import pyodbc
@@ -71,6 +71,27 @@ def cursor() -> Iterator[pyodbc.Cursor]:
     cur.execute("drop table if exists t2")
     cur.execute("drop table if exists t3")
     cnxn.commit()
+
+    yield cur
+
+    if not cnxn.closed:
+        cur.close()
+        cnxn.close()
+
+
+# Enabling the SQL Server bulk copy (BCP) API requires the connection to be
+# opened with the SQL_COPT_SS_BCP attribute set, so BCP tests use their own
+# connection rather than the shared one above.
+SQL_COPT_SS_BCP = 1219
+SQL_BCP_ON = 1
+
+
+@pytest.fixture
+def bcp_cursor() -> Iterator[pyodbc.Cursor]:
+    cnxn = connect(autocommit=True, attrs_before={SQL_COPT_SS_BCP: SQL_BCP_ON})
+    cur = cnxn.cursor()
+
+    cur.execute("drop table if exists t1")
 
     yield cur
 
@@ -1557,6 +1578,136 @@ def test_emoticons_as_literal(cursor: pyodbc.Cursor):
     result = cursor.execute("select s from t1").fetchone()[0]
 
     assert result == v
+
+
+# A fixed timezone for the datetimeoffset column in the BCP type-coverage test.
+_BCP_TZ = timezone(timedelta(hours=5, minutes=30))
+
+# Reason used to skip the BCP tests when the driver is not the Microsoft one.
+_BCP_SKIP = 'BCP requires the Microsoft ODBC Driver for SQL Server'
+
+
+def _bcp_row(i: int) -> tuple:
+    """Build one row covering every Python type the BCP fast path supports."""
+    return (
+        i,                                                  # c_int       INT
+        5_000_000_000 + i,                                  # c_bigint    BIGINT (> 32 bits)
+        bool(i % 2),                                        # c_bit       BIT
+        i + 0.5,                                            # c_float     FLOAT
+        "x" * (i % 400),                            # c_varchar   VARCHAR (varying length)
+        Decimal(f"{i}.{i % 10000:04d}"),            # c_decimal   DECIMAL(18,4)
+        Decimal(10 ** 20 + i),                      # c_numeric   NUMERIC(38,0) (> 64 bits)
+        time(i % 24, i % 60, (i * 7) % 60, (i * 101) % 1000000),  # c_time   TIME(7)
+        date(2020, (i % 12) + 1, (i % 28) + 1),     # c_date      DATE
+        datetime(2021, (i % 12) + 1, (i % 28) + 1,
+                 i % 24, i % 60, (i * 7) % 60, (i * 101) % 1000000),  # c_datetime2
+        datetime(2022, (i % 12) + 1, (i % 28) + 1,
+                 i % 24, i % 60, (i * 7) % 60, (i * 101) % 1000000,
+                 tzinfo=_BCP_TZ),                   # c_dto       DATETIMEOFFSET(7)
+    )
+
+
+@pytest.mark.skipif(not IS_MSODBCSQL, reason=_BCP_SKIP)
+def test_bcp_fast_executemany(bcp_cursor: pyodbc.Cursor):
+    # The BCP fast path (cursor.use_bcp_fast) routes fast_executemany through the
+    # SQL Server bulk-copy API.  Verify it inserts correctly across every
+    # supported Python type, including NULLs, variable-length growth (varchar
+    # past the initial buffer), values that exceed 32/64 bits, and manual
+    # batching.
+    cur = bcp_cursor
+    cur.execute(
+        """
+        create table t1(
+            c_int       int,
+            c_bigint    bigint,
+            c_bit       bit,
+            c_float     float,
+            c_varchar   varchar(1000),
+            c_decimal   decimal(18, 4),
+            c_numeric   numeric(38, 0),
+            c_time      time(7),
+            c_date      date,
+            c_datetime2 datetime2(7),
+            c_dto       datetimeoffset(7))
+        """)
+
+    n = 500
+    null_row = 7
+    rows = [_bcp_row(i) for i in range(n)]
+    rows[null_row] = (null_row,) + (None,) * 10   # NULL every column except the key
+
+    cur.fast_executemany = True
+    cur.use_bcp_fast = True
+    cur.bcp_batch_rows = 100                          # exercise batching
+    # No explicit column list: BCP binds by ordinal, and only a plain VALUES
+    # insert takes the BCP path (see parse_insert_table); the row tuples are in
+    # table-column order.
+    cur.executemany(
+        "insert into t1 values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+
+    assert cur.execute("select count(*) from t1").fetchval() == n
+
+    # pyodbc cannot natively decode datetimeoffset (SQL type -155) on fetch, so
+    # the datetimeoffset column is read back as its wall-clock datetime2 plus the
+    # UTC offset in minutes; the other ten columns are compared directly.
+    fetch_cols = ("c_int, c_bigint, c_bit, c_float, c_varchar, c_decimal, c_numeric, "
+                  "c_time, c_date, c_datetime2, "
+                  "cast(c_dto as datetime2(7)), datepart(tzoffset, c_dto)")
+
+    # A fully-populated row round-trips exactly across every type.
+    expected = _bcp_row(123)
+    row = cur.execute(f"select {fetch_cols} from t1 where c_int = 123").fetchone()
+    assert tuple(row)[:10] == expected[:10]
+    assert row[10] == expected[10].replace(tzinfo=None)   # datetimeoffset wall time
+    assert row[11] == 330                                 # +05:30 offset in minutes
+    # Spot-check the type mapping on the trickier columns.
+    assert isinstance(row.c_decimal, Decimal)
+    assert isinstance(row.c_bit, bool)
+
+    # The all-NULL row round-trips as None in every nullable column.
+    row = cur.execute(f"select {fetch_cols} from t1 where c_int = {null_row}").fetchone()
+    assert row.c_int == null_row
+    assert all(v is None for v in tuple(row)[1:])
+
+    # NULLs are isolated to that single row.
+    assert cur.execute("select count(*) from t1 where c_dto is null").fetchval() == 1
+
+
+@pytest.mark.skipif(not IS_MSODBCSQL, reason=_BCP_SKIP)
+def test_bcp_fast_executemany_column_list(bcp_cursor: pyodbc.Cursor):
+    # BCP loads by table ordinal, so an explicit column list must be mapped to
+    # the destination's column positions.  This is the shape SQLAlchemy emits
+    # (INSERT INTO t (cols...) VALUES (...)), including lists that reorder or
+    # subset the table's columns.
+    cur = bcp_cursor
+    cur.execute("create table t1(a int, b varchar(20), c int, d float)")
+
+    cur.fast_executemany = True
+    cur.use_bcp_fast = True
+
+    # Column list in a different order than the table's physical columns; the
+    # row tuples follow the list order (c, a, b, d).
+    reordered = [(i * 10, i, f"b{i}", i + 0.5) for i in range(50)]
+    cur.executemany("insert into t1 (c, a, b, d) values (?, ?, ?, ?)", reordered)
+
+    row = cur.execute("select a, b, c, d from t1 where a = 7").fetchone()
+    assert row.a == 7
+    assert row.b == "b7"
+    assert row.c == 70
+    assert row.d == 7.5
+    assert cur.execute("select count(*) from t1").fetchval() == 50
+
+    # A column subset: the unlisted columns (c, d) must round-trip as NULL.
+    cur.execute("truncate table t1")
+    subset = [(i, f"name{i}") for i in range(20)]
+    cur.executemany("insert into t1 (a, b) values (?, ?)", subset)
+
+    row = cur.execute("select a, b, c, d from t1 where a = 3").fetchone()
+    assert row.a == 3
+    assert row.b == "name3"
+    assert row.c is None
+    assert row.d is None
+    assert cur.execute("select count(*) from t1").fetchval() == 20
 
 
 def _test_tvp(cursor: pyodbc.Cursor, diff_schema):

--- a/utils/bcp_benchmark.py
+++ b/utils/bcp_benchmark.py
@@ -1,0 +1,103 @@
+"""Standalone benchmark for the SQL Server BCP fast path.
+
+Compares row-by-row executemany, fast_executemany, and the BCP fast path
+(with and without the TABLOCK hint) for a bulk insert into a heap table.
+
+This is a manual benchmark, not a pytest test; it lives in utils/ rather than
+tests/ so it is never collected by pytest.  Run it directly:
+
+    PYODBC_SQLSERVER="DRIVER={ODBC Driver 18 for SQL Server};SERVER=...;..." \\
+        python utils/bcp_benchmark.py [bulk_rows]
+
+The connection string is read from the PYODBC_SQLSERVER environment variable
+(falling back to the DSN 'pyodbc-sqlserver'); the optional argument overrides
+the number of rows used for the bulk methods.
+"""
+
+import os
+import sys
+from datetime import datetime
+from time import perf_counter
+
+import pyodbc
+
+CNXNSTR = os.environ.get('PYODBC_SQLSERVER', 'DSN=pyodbc-sqlserver')
+
+SQL_COPT_SS_BCP = 1219
+SQL_BCP_ON = 1
+
+# Number of rows for the row-by-row reference (kept small) and the bulk methods.
+SLOW_ROWS = 5_000
+BULK_ROWS = 1_000_000
+BATCH_ROWS = 20_000
+
+
+def make_data(n):
+    return [
+        (i, float(i) * 1.1, f"row {i}", datetime(2020, 1, (i % 28) + 1, 12, 0, 0, i % 1000))
+        for i in range(n)
+    ]
+
+
+def report(label, n, secs):
+    rate = n / secs if secs > 0 else float("inf")
+    print(f"{label:<22} {n:>9,} rows in {secs:8.3f}s  ({rate:>12,.0f} rows/s)")
+
+
+def run_method(cursor, sql, data, *, fast, bcp, tablock):
+    cursor.execute("truncate table bcp_benchmark")
+    cursor.fast_executemany = fast
+    cursor.use_bcp_fast = bcp
+    if bcp:
+        cursor.bcp_batch_rows = BATCH_ROWS
+        cursor.bcp_tablock = tablock
+    start = perf_counter()
+    cursor.executemany(sql, data)
+    return perf_counter() - start
+
+
+def main():
+    bulk_rows = int(sys.argv[1]) if len(sys.argv) > 1 else BULK_ROWS
+
+    cnxn = pyodbc.connect(CNXNSTR, autocommit=True,
+                          attrs_before={SQL_COPT_SS_BCP: SQL_BCP_ON})
+    cursor = cnxn.cursor()
+
+    rm = cursor.execute(
+        "select recovery_model_desc from sys.databases where database_id = db_id()"
+    ).fetchval()
+    print(f"recovery model: {rm}")
+
+    cursor.execute("drop table if exists bcp_benchmark")
+    cursor.execute(
+        """
+        create table bcp_benchmark(
+            id          int,
+            value       float,
+            description varchar(100),
+            created_at  datetime2(7))
+        """)
+
+    sql = "insert into bcp_benchmark values (?, ?, ?, ?)"
+    slow_data = make_data(SLOW_ROWS)
+    bulk_data = make_data(bulk_rows)
+
+    report("executemany", SLOW_ROWS,
+           run_method(cursor, sql, slow_data, fast=False, bcp=False, tablock=False))
+    report("fast_executemany", bulk_rows,
+           run_method(cursor, sql, bulk_data, fast=True, bcp=False, tablock=False))
+    report("BCP (no TABLOCK)", bulk_rows,
+           run_method(cursor, sql, bulk_data, fast=True, bcp=True, tablock=False))
+    report("BCP (TABLOCK)", bulk_rows,
+           run_method(cursor, sql, bulk_data, fast=True, bcp=True, tablock=True))
+
+    count = cursor.execute("select count(*) from bcp_benchmark").fetchval()
+    print(f"final row count: {count:,} (expected {bulk_rows:,})")
+
+    cursor.execute("drop table if exists bcp_benchmark")
+    cursor.close()
+    cnxn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This adds an **optional SQL Server BCP (bulk copy) fast path** for
`Cursor.executemany()` when `fast_executemany` is enabled. When turned on, an
`INSERT ... VALUES (...)` executemany is routed through the SQL Server bulk-copy
API (`bcp_init` / `bcp_bind` / `bcp_sendrow` / `bcp_batch` / `bcp_done`) instead
of parameter-array `INSERT`s. For large loads this is dramatically faster,
because it bypasses per-statement query processing.

It is **opt-in and safe**: if BCP can't be used for a given call (not a
parameterized `VALUES` insert, an unsupported value type, a partial column list,
a non-Microsoft driver, etc.) it transparently falls back to the existing
`fast_executemany` path. The BCP entry points are **loaded on demand from the
in-use `msodbcsql` driver**, so there is no new build/link dependency.

## Relationship to #1486

#1486 ("Implement bulk copy support") and this PR tackle bulk copy from
different angles and are **complementary, not competing**:

- **#1486** adds a `connection.bcp(...)` method that bulk-copies between a
  **data file** and a table (`bcp_init`/`bcp_readfmt`/`bcp_exec` + a format
  file), supporting both import and **export** — the classic `bcp` utility
  exposed programmatically. You bring a file (and a format file).
- **This PR** accelerates **in-memory** `cursor.executemany()` /
  `fast_executemany` (and SQLAlchemy) inserts by streaming the Python rows
  through `bcp_bind`/`bcp_sendrow` — no data file or format file. Import only.

The only overlap is low-level plumbing: both enable `SQL_COPT_SS_BCP` and
dynamically load the driver's `bcp_*` entry points (and define the same
`SQL_COPT_SS_BCP`/`SQL_BCP_ON` constants). If #1486 lands first — or the
maintainers prefer a single BCP module — I'm happy to rebase this on top and
share that infrastructure (a common `bcp_*` symbol loader + constants) rather
than duplicate it.

## How to use (raw pyodbc)

BCP must be enabled on the connection *before* connecting, via the SQL
Server-specific `SQL_COPT_SS_BCP` pre-connect attribute:

```python
import pyodbc

SQL_COPT_SS_BCP = 1219
SQL_BCP_ON = 1

cnxn = pyodbc.connect(connection_string,
                      autocommit=True,
                      attrs_before={SQL_COPT_SS_BCP: SQL_BCP_ON})

cur = cnxn.cursor()
cur.fast_executemany = True      # required
cur.use_bcp_fast = True          # opt into the BCP path
cur.bcp_batch_rows = 10_000      # optional: rows per committed batch (0 = one batch)
cur.bcp_tablock = True           # optional: pass the TABLOCK hint

cur.executemany(
    "INSERT INTO dbo.target (a, b, c) VALUES (?, ?, ?)",
    rows)
```

New `Cursor` attributes:

| attribute | type | meaning |
|-----------|------|---------|
| `use_bcp_fast` | bool | route `fast_executemany` through BCP when possible |
| `bcp_batch_rows` | int | rows per committed batch (`0` = a single batch) |
| `bcp_tablock` | bool | pass the `TABLOCK` hint (bulk-update lock; can enable minimal logging) |

`AUTOCOMMIT` is recommended for BCP loads (the bulk copy is committed by
`bcp_done`/`bcp_batch`).

## How to use via SQLAlchemy

Enable BCP on the connection through `connect_args`, and flip `use_bcp_fast` on
each `executemany` with a `before_cursor_execute` listener:

```python
import sqlalchemy as sa
from sqlalchemy import event

SQL_COPT_SS_BCP = 1219
SQL_BCP_ON = 1

engine = sa.create_engine(
    "mssql+pyodbc://user:pwd@host/db?driver=ODBC+Driver+18+for+SQL+Server",
    connect_args={"attrs_before": {SQL_COPT_SS_BCP: SQL_BCP_ON}},
    fast_executemany=True,           # SQLAlchemy sets cursor.fast_executemany
    isolation_level="AUTOCOMMIT",
)

@event.listens_for(engine, "before_cursor_execute")
def _enable_bcp(conn, cursor, statement, parameters, context, executemany):
    if executemany:
        cursor.use_bcp_fast = True
        cursor.bcp_batch_rows = 10_000
        # cursor.bcp_tablock = True

with engine.begin() as conn:
    conn.execute(sa.insert(my_table), list_of_dicts)
```

SQLAlchemy emits an explicit column list (`INSERT INTO t (cols...) VALUES (...)`).
That is handled correctly (see below). When SQLAlchemy omits columns from the
list (e.g. an identity PK or a server-default column), the insert is a *partial*
list and falls back to `fast_executemany` (BCP requires every column to be
bound). Full-column bulk inserts -- the typical high-volume case -- use BCP.

## Column-list handling

BCP loads by **table column ordinal**, not by name, so an explicit column list
is mapped to ordinals before binding:

- **No column list** (`INSERT INTO t VALUES (?, ...)`): bound positionally.
- **Explicit list, any order** (`INSERT INTO t (c, a, b) VALUES (...)`): each
  listed name is resolved to its table ordinal via `SQLColumnsW`, so values land
  in the right columns regardless of list order. Non-ASCII column names work.
  The lookup is pinned to the schema `bcp_init` targets (the declared schema, or
  `SCHEMA_NAME()` when omitted) to avoid cross-schema ambiguity.
- **Partial list** (fewer columns than the table), **`INSERT ... SELECT/EXEC`**,
  **`DEFAULT VALUES`**, duplicate column names: fall back to the normal path.

## Supported value types

Host column types are deduced from the **first row**:

- `int` -> `INT` (or `BIGINT` when it doesn't fit 32 bits; out-of-range values raise)
- `bool` -> `BIT`
- `float` -> `FLOAT`
- `str` / `bytes` / `bytearray` -> character
- `Decimal` -> sent as text (non-finite values rejected)
- `datetime.date` / `time` / `datetime` (naive and tz-aware) -> sent as ISO text,
  letting the server convert to `DATE`/`TIME`/`DATETIME2`/`DATETIMEOFFSET`
- `None` -> SQL `NULL`

Any other value type (e.g. `uuid.UUID`) causes that `executemany` to fall back.

## Behaviour / fallback

`executemany` falls back to the existing `fast_executemany` implementation (no
error) whenever BCP can't be used. `bcp_init` is started only after the rows
validate and the column buffers are allocated, and every error path afterwards
calls `bcp_done`, so a failed row never leaves the connection mid-bulk-copy.

## What is **not** done / limitations

- **SQL Server + `msodbcsql` only.** Other drivers/databases fall back.
- **Native binary temporal types are not enabled.** `date`/`time`/`datetime2`/
  `datetimeoffset` are sent as ISO text and converted server-side. The native
  length-prefixed binary bind is implemented but disabled: `bcp_bind` does not
  carry the fractional-second scale, so the driver rejects sub-second values.
  `Decimal` is likewise sent as text.
- **Types are deduced from the first row**, so provide representative first rows
  (or leave `use_bcp_fast` off) for heterogeneous data.
- `bytes` are bound as character data, not `VARBINARY`.
- Reading a `DATETIMEOFFSET` column back is unrelated to this change but worth
  noting: pyodbc has no native decoder for SQL type `-155`.

## Performance

Measured in CI inserting into a heap table `(INT, FLOAT, VARCHAR(100),
DATETIME2(7))`. The first method uses fewer rows because the row-by-row path is
slow; the bulk methods use 100k rows. Database in **FULL** recovery:

| method | rows | time | rate |
|---|---:|---:|---:|
| `executemany` (row-by-row) | 5,000 | 3.36 s | ~1,500 rows/s |
| `fast_executemany` | 100,000 | 37.3 s | ~2,700 rows/s |
| BCP, no `TABLOCK` | 100,000 | 0.367 s | ~272,000 rows/s |
| BCP, `TABLOCK` | 100,000 | 0.370 s | ~270,000 rows/s |

A separate run under **SIMPLE** recovery produced effectively the same figures.

Takeaways:

- BCP is roughly **two orders of magnitude** faster than `fast_executemany` here.
- Almost all of the gain comes from the **BCP protocol itself**, not minimal
  logging: `TABLOCK` made a negligible difference at this size, and the result
  held under both FULL and SIMPLE recovery.
- **Caveat:** this is a small, shared CI runner where `fast_executemany` is
  abnormally slow (~2,700 rows/s), which inflates the multiple. On capable
  hardware the gap will be smaller, but BCP remains clearly faster for bulk loads.

## Tests

`tests/sqlserver_test.py::test_bcp_fast_executemany` covers all supported types,
`NULL`s, variable-length growth, `>32/64`-bit integers and batching (plain
`VALUES`, positional binding). `test_bcp_fast_executemany_column_list` covers an
explicit list that reorders columns (via BCP) and a column subset (falls back).
`utils/bcp_benchmark.py` is a standalone benchmark (kept under `utils/` so it is
never collected by pytest, per `CLAUDE.md`). The full CI matrix (Python
3.10-3.14 x SQL Server 2019/2022/2025 + PostgreSQL / MySQL / SQLite) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
